### PR TITLE
Merge AIDA DSP changes into public codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+build
+bins
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.7.2)
+project(Dev-Portal VERSION 0.9.0)
+
+add_subdirectory(examples)
+
+#add_subdirectory(featured/aida-x-player)
+
+add_subdirectory(featured/aida-x-convolver)
+
+add_subdirectory(featured/aida-x-tests)
+
+add_subdirectory(tests)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# How to use
+# docker buildx build --platform linux/arm -t chaos-audio-builder --load .
+# docker run --rm -it -u $UID --platform linux/arm -v "$(pwd):/workdir" chaos-audio-builder # Cross-compilation x86_64 to arm/v7
+
+FROM debian:bullseye-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workdir
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/common/Biquad.cpp
+++ b/common/Biquad.cpp
@@ -1,0 +1,165 @@
+//
+//  Biquad.cpp
+//
+//  Created by Nigel Redmon on 11/24/12
+//  EarLevel Engineering: earlevel.com
+//  Copyright 2012 Nigel Redmon
+//
+//  For a complete explanation of the Biquad code:
+//  http://www.earlevel.com/main/2012/11/26/biquad-c-source-code/
+//
+//  License:
+//
+//  This source code is provided as is, without warranty.
+//  You may copy and distribute verbatim copies of this document.
+//  You may modify and use this source code to create binary code
+//  for your own purposes, free or commercial.
+//
+
+#include <math.h>
+#include "Biquad.h"
+
+Biquad::Biquad() {
+    type = bq_type_lowpass;
+    a0 = 1.0;
+    a1 = a2 = b1 = b2 = 0.0;
+    Fc = 0.50;
+    Q = 0.707;
+    peakGain = 0.0;
+    z1 = z2 = 0.0;
+}
+
+Biquad::Biquad(int type, double Fc, double Q, double peakGainDB) {
+    setBiquad(type, Fc, Q, peakGainDB);
+    z1 = z2 = 0.0;
+}
+
+Biquad::~Biquad() {
+}
+
+void Biquad::setType(int type) {
+    this->type = type;
+    calcBiquad();
+}
+
+void Biquad::setQ(double Q) {
+    this->Q = Q;
+    calcBiquad();
+}
+
+void Biquad::setFc(double Fc) {
+    this->Fc = Fc;
+    calcBiquad();
+}
+
+void Biquad::setPeakGain(double peakGainDB) {
+    this->peakGain = peakGainDB;
+    calcBiquad();
+}
+
+void Biquad::setBiquad(int type, double Fc, double Q, double peakGainDB) {
+    this->type = type;
+    this->Q = Q;
+    this->Fc = Fc;
+    setPeakGain(peakGainDB);
+}
+
+void Biquad::calcBiquad(void) {
+    double norm;
+    double V = pow(10, fabs(peakGain) / 20.0);
+    double K = tan(M_PI * Fc);
+    switch (this->type) {
+        case bq_type_lowpass:
+            norm = 1 / (1 + K / Q + K * K);
+            a0 = K * K * norm;
+            a1 = 2 * a0;
+            a2 = a0;
+            b1 = 2 * (K * K - 1) * norm;
+            b2 = (1 - K / Q + K * K) * norm;
+            break;
+
+        case bq_type_highpass:
+            norm = 1 / (1 + K / Q + K * K);
+            a0 = 1 * norm;
+            a1 = -2 * a0;
+            a2 = a0;
+            b1 = 2 * (K * K - 1) * norm;
+            b2 = (1 - K / Q + K * K) * norm;
+            break;
+
+        case bq_type_bandpass:
+            norm = 1 / (1 + K / Q + K * K);
+            a0 = K / Q * norm;
+            a1 = 0;
+            a2 = -a0;
+            b1 = 2 * (K * K - 1) * norm;
+            b2 = (1 - K / Q + K * K) * norm;
+            break;
+
+        case bq_type_notch:
+            norm = 1 / (1 + K / Q + K * K);
+            a0 = (1 + K * K) * norm;
+            a1 = 2 * (K * K - 1) * norm;
+            a2 = a0;
+            b1 = a1;
+            b2 = (1 - K / Q + K * K) * norm;
+            break;
+
+        case bq_type_peak:
+            if (peakGain >= 0) {    // boost
+                norm = 1 / (1 + 1/Q * K + K * K);
+                a0 = (1 + V/Q * K + K * K) * norm;
+                a1 = 2 * (K * K - 1) * norm;
+                a2 = (1 - V/Q * K + K * K) * norm;
+                b1 = a1;
+                b2 = (1 - 1/Q * K + K * K) * norm;
+            }
+            else {    // cut
+                norm = 1 / (1 + V/Q * K + K * K);
+                a0 = (1 + 1/Q * K + K * K) * norm;
+                a1 = 2 * (K * K - 1) * norm;
+                a2 = (1 - 1/Q * K + K * K) * norm;
+                b1 = a1;
+                b2 = (1 - V/Q * K + K * K) * norm;
+            }
+            break;
+        case bq_type_lowshelf:
+            if (peakGain >= 0) {    // boost
+                norm = 1 / (1 + sqrt(2) * K + K * K);
+                a0 = (1 + sqrt(2*V) * K + V * K * K) * norm;
+                a1 = 2 * (V * K * K - 1) * norm;
+                a2 = (1 - sqrt(2*V) * K + V * K * K) * norm;
+                b1 = 2 * (K * K - 1) * norm;
+                b2 = (1 - sqrt(2) * K + K * K) * norm;
+            }
+            else {    // cut
+                norm = 1 / (1 + sqrt(2*V) * K + V * K * K);
+                a0 = (1 + sqrt(2) * K + K * K) * norm;
+                a1 = 2 * (K * K - 1) * norm;
+                a2 = (1 - sqrt(2) * K + K * K) * norm;
+                b1 = 2 * (V * K * K - 1) * norm;
+                b2 = (1 - sqrt(2*V) * K + V * K * K) * norm;
+            }
+            break;
+        case bq_type_highshelf:
+            if (peakGain >= 0) {    // boost
+                norm = 1 / (1 + sqrt(2) * K + K * K);
+                a0 = (V + sqrt(2*V) * K + K * K) * norm;
+                a1 = 2 * (K * K - V) * norm;
+                a2 = (V - sqrt(2*V) * K + K * K) * norm;
+                b1 = 2 * (K * K - 1) * norm;
+                b2 = (1 - sqrt(2) * K + K * K) * norm;
+            }
+            else {    // cut
+                norm = 1 / (V + sqrt(2*V) * K + K * K);
+                a0 = (1 + sqrt(2) * K + K * K) * norm;
+                a1 = 2 * (K * K - 1) * norm;
+                a2 = (1 - sqrt(2) * K + K * K) * norm;
+                b1 = 2 * (K * K - V) * norm;
+                b2 = (V - sqrt(2*V) * K + K * K) * norm;
+            }
+            break;
+    }
+
+    return;
+}

--- a/common/Biquad.h
+++ b/common/Biquad.h
@@ -1,0 +1,60 @@
+//
+//  Biquad.h
+//
+//  Created by Nigel Redmon on 11/24/12
+//  EarLevel Engineering: earlevel.com
+//  Copyright 2012 Nigel Redmon
+//
+//  For a complete explanation of the Biquad code:
+//  http://www.earlevel.com/main/2012/11/26/biquad-c-source-code/
+//
+//  License:
+//
+//  This source code is provided as is, without warranty.
+//  You may copy and distribute verbatim copies of this document.
+//  You may modify and use this source code to create binary code
+//  for your own purposes, free or commercial.
+//
+
+#ifndef Biquad_h
+#define Biquad_h
+
+enum {
+    bq_type_lowpass = 0,
+    bq_type_highpass,
+    bq_type_bandpass,
+    bq_type_notch,
+    bq_type_peak,
+    bq_type_lowshelf,
+    bq_type_highshelf
+};
+
+class Biquad {
+public:
+    Biquad();
+    Biquad(int type, double Fc, double Q, double peakGainDB);
+    ~Biquad();
+    void setType(int type);
+    void setQ(double Q);
+    void setFc(double Fc);
+    void setPeakGain(double peakGainDB);
+    void setBiquad(int type, double Fc, double Q, double peakGainDB);
+    float process(float in);
+
+protected:
+    void calcBiquad(void);
+
+    int type;
+    double a0, a1, a2, b1, b2;
+    double Fc, Q, peakGain;
+    double z1, z2;
+};
+
+inline float Biquad::process(float in) {
+    double out = in * a0 + z1;
+    z1 = in * a1 + z2 - b1 * out;
+    z2 = in * a2 - b2 * out;
+    return out;
+}
+
+#endif // Biquad_h

--- a/common/Eq2Bands.hpp
+++ b/common/Eq2Bands.hpp
@@ -1,0 +1,52 @@
+/*
+ * AIDA-X Eq2Bands base class for Chaos Audio
+ * Copyright (C) 2024 Massimo Pennazio <maxipenna@libero.it>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef EQ2BANDS_HPP
+#define EQ2BANDS_HPP
+
+#include <cstdint>
+
+#include <Biquad.h>
+
+class Eq2Bands {
+private:
+    float samplerate = 44100;
+    Biquad *bass;
+    Biquad *treble;
+
+    void applyBiquadFilter(float *out, const float *in, Biquad *filter, uint32_t n_samples) {
+        for(uint32_t i=0; i<n_samples; i++) {
+            out[i] = filter->process(in[i]);
+        }
+    }
+
+public:
+    float bass_freq;
+    float treble_freq;
+
+    Eq2Bands(float sr) : samplerate(sr) {
+        // Setup equalizer section
+        bass_freq = 250.0f;
+        bass = new Biquad(bq_type_highpass, bass_freq / samplerate, 0.707f, 0.0f);
+        treble_freq = 1500.0f;
+        treble = new Biquad(bq_type_lowpass, treble_freq / samplerate, 0.707f, 0.0f);
+    }
+
+    void updateBass() {
+        bass->setBiquad(bq_type_highpass, bass_freq / samplerate, 0.707f, 0.0f);
+    }
+
+    void updateTreble() {
+        treble->setBiquad(bq_type_lowpass, treble_freq / samplerate, 0.707f, 0.0f);
+    }
+
+    void process(int count, const float* input, float* output) {
+        applyBiquadFilter(output, input, bass, count);
+        applyBiquadFilter(output, output, treble, count);
+    }
+};
+
+#endif // EQ2BANDS_HPP

--- a/common/Eq5Bands.hpp
+++ b/common/Eq5Bands.hpp
@@ -1,0 +1,102 @@
+/*
+ * AIDA-X Eq5Bands base class for Chaos Audio
+ * Copyright (C) 2024 Massimo Pennazio <maxipenna@libero.it>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef EQ5BANDS_HPP
+#define EQ5BANDS_HPP
+
+#include <cstdint>
+
+#include <Biquad.h>
+
+/* Defines for tone controls */
+#define PEAK 0.0f
+#define BANDPASS 1.0f
+#define DEPTH_FREQ 75.0f
+#define DEPTH_Q 0.707f
+#define PRESENCE_FREQ 900.0f
+#define PRESENCE_Q 0.707f
+
+class Eq5Bands {
+private:
+    float samplerate = 44100;
+    Biquad *bass;
+    Biquad *mid;
+    Biquad *treble;
+    Biquad *depth;
+    Biquad *presence;
+
+    void applyBiquadFilter(float *out, const float *in, Biquad *filter, uint32_t n_samples) {
+        for(uint32_t i=0; i<n_samples; i++) {
+            out[i] = filter->process(in[i]);
+        }
+    }
+
+public:
+    float bass_boost_db;
+    float bass_freq;
+    float mid_boost_db;
+    float mid_freq;
+    float mid_q;
+    uint8_t mid_type;
+    float treble_boost_db;
+    float treble_freq;
+    float depth_boost_db;
+    float presence_boost_db;
+
+    Eq5Bands(float sr) : samplerate(sr) {
+        // Setup equalizer section
+        bass_boost_db = 0.0f;
+        bass_freq = 250.0f;
+        bass = new Biquad(bq_type_lowshelf, bass_freq / samplerate, 0.707f, bass_boost_db);
+        mid_boost_db = 0.0f;
+        mid_freq = 600.0f;
+        mid_q = 0.707f;
+        mid_type = 0;
+        mid = new Biquad(bq_type_peak, mid_freq / samplerate, mid_q, mid_boost_db);
+        treble_boost_db = 0.0f;
+        treble_freq = 1500.0f;
+        treble = new Biquad(bq_type_highshelf, treble_freq / samplerate, 0.707f, treble_boost_db);
+        depth_boost_db = 0.0f;
+        depth = new Biquad(bq_type_peak, DEPTH_FREQ / samplerate, DEPTH_Q, depth_boost_db);
+        presence_boost_db = 0.0f;
+        presence = new Biquad(bq_type_highshelf, PRESENCE_FREQ / samplerate, PRESENCE_Q, presence_boost_db);
+    }
+
+    void updateBass() {
+        bass->setBiquad(bq_type_lowshelf, bass_freq / samplerate, 0.707f, bass_boost_db);
+    }
+
+    void updateMid() {
+        if(mid_type) {
+            mid->setBiquad(bq_type_bandpass, mid_freq / samplerate, mid_q, mid_boost_db);
+        }
+        else {
+           mid->setBiquad(bq_type_peak, mid_freq / samplerate, mid_q, mid_boost_db);
+        }
+    }
+
+    void updateTreble() {
+        treble->setBiquad(bq_type_highshelf, treble_freq / samplerate, 0.707f, treble_boost_db);
+    }
+
+    void updateDepth() {
+        depth->setBiquad(bq_type_peak, DEPTH_FREQ / samplerate, DEPTH_Q, depth_boost_db);
+    }
+
+    void updatePresence() {
+        presence->setBiquad(bq_type_highshelf, PRESENCE_FREQ / samplerate, PRESENCE_Q, presence_boost_db);
+    }
+
+    void process(int count, const float* input, float* output) {
+        applyBiquadFilter(output, input, bass, count);
+        applyBiquadFilter(output, output, mid, count);
+        applyBiquadFilter(output, output, treble, count);
+        applyBiquadFilter(output, output, depth, count);
+        applyBiquadFilter(output, output, presence, count);
+    }
+};
+
+#endif // EQ5BANDS_HPP

--- a/common/ValueSmoother.hpp
+++ b/common/ValueSmoother.hpp
@@ -1,0 +1,245 @@
+/*
+ * DISTRHO Plugin Framework (DPF)
+ * Copyright (C) 2021 Jean Pierre Cimalando <jp-dev@inbox.ru>
+ * Copyright (C) 2021-2023 Filipe Coelho <falktx@falktx.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any purpose with
+ * or without fee is hereby granted, provided that the above copyright notice and this
+ * permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD
+ * TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN
+ * NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef DISTRHO_VALUE_SMOOTHER_HPP_INCLUDED
+#define DISTRHO_VALUE_SMOOTHER_HPP_INCLUDED
+
+#include <cmath>
+#include <limits>
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/**
+   Safely compare two floating point numbers.
+   Returns true if they match.
+ */
+template<typename T>
+static inline constexpr
+bool d_isEqual(const T& v1, const T& v2)
+{
+    return std::abs(v1-v2) < std::numeric_limits<T>::epsilon();
+}
+
+/**
+   Safely compare two floating point numbers.
+   Returns true if they don't match.
+ */
+template<typename T>
+static inline constexpr
+bool d_isNotEqual(const T& v1, const T& v2)
+{
+    return std::abs(v1-v2) >= std::numeric_limits<T>::epsilon();
+}
+
+/**
+   Safely check if a floating point number is zero.
+ */
+template<typename T>
+static inline constexpr
+bool d_isZero(const T& value)
+{
+    return std::abs(value) < std::numeric_limits<T>::epsilon();
+}
+
+/**
+   Safely check if a floating point number is not zero.
+ */
+template<typename T>
+static inline constexpr
+bool d_isNotZero(const T& value)
+{
+    return std::abs(value) >= std::numeric_limits<T>::epsilon();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/**
+ * @brief An exponential smoother for control values
+ *
+ * This continually smooths a value towards a defined target,
+ * using a low-pass filter of the 1st order, which creates an exponential curve.
+ *
+ * The length of the curve is defined by a T60 constant,
+ * which is the time it takes for a 1-to-0 smoothing to fall to -60dB.
+ *
+ * Note that this smoother has asymptotical behavior,
+ * and it must not be assumed that the final target is ever reached.
+ */
+class ExponentialValueSmoother {
+    float coef;
+    float target;
+    float mem;
+    float tau;
+    float sampleRate;
+
+public:
+    ExponentialValueSmoother()
+        : coef(0.f),
+          target(0.f),
+          mem(0.f),
+          tau(0.f),
+          sampleRate(0.f) {}
+
+    void setSampleRate(const float newSampleRate) noexcept
+    {
+        if (d_isNotEqual(sampleRate, newSampleRate))
+        {
+            sampleRate = newSampleRate;
+            updateCoef();
+        }
+    }
+
+    void setTimeConstant(const float newT60) noexcept
+    {
+        const float newTau = newT60 * (float)(1.0 / 6.91);
+
+        if (d_isNotEqual(tau, newTau))
+        {
+            tau = newTau;
+            updateCoef();
+        }
+    }
+
+    float getCurrentValue() const noexcept
+    {
+        return mem;
+    }
+
+    float getTargetValue() const noexcept
+    {
+        return target;
+    }
+
+    void setTargetValue(const float newTarget) noexcept
+    {
+        target = newTarget;
+    }
+
+    void clearToTargetValue() noexcept
+    {
+        mem = target;
+    }
+
+    inline float peek() const noexcept
+    {
+        return mem * coef + target * (1.f - coef);
+    }
+
+    inline float next() noexcept
+    {
+        return (mem = mem * coef + target * (1.f - coef));
+    }
+
+private:
+    void updateCoef() noexcept
+    {
+        coef = std::exp(-1.f / (tau * sampleRate));
+    }
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/**
+ * @brief A linear smoother for control values
+ *
+ * This continually smooths a value towards a defined target, using linear segments.
+ *
+ * The duration of the smoothing segment is defined by the given time constant.
+ * Every time the target changes, a new segment restarts for the whole duration of the time constant.
+ *
+ * Note that this smoother, unlike an exponential smoother, eventually should converge to its target value.
+ */
+class LinearValueSmoother {
+    float step;
+    float target;
+    float mem;
+    float tau;
+    float sampleRate;
+
+public:
+    LinearValueSmoother()
+        : step(0.f),
+          target(0.f),
+          mem(0.f),
+          tau(0.f),
+          sampleRate(0.f) {}
+
+    void setSampleRate(const float newSampleRate) noexcept
+    {
+        if (d_isNotEqual(sampleRate, newSampleRate))
+        {
+            sampleRate = newSampleRate;
+            updateStep();
+        }
+    }
+
+    void setTimeConstant(const float newTau) noexcept
+    {
+        if (d_isNotEqual(tau, newTau))
+        {
+            tau = newTau;
+            updateStep();
+        }
+    }
+
+    float getCurrentValue() const noexcept
+    {
+        return mem;
+    }
+
+    float getTargetValue() const noexcept
+    {
+        return target;
+    }
+
+    void setTargetValue(const float newTarget) noexcept
+    {
+        if (d_isNotEqual(target, newTarget))
+        {
+            target = newTarget;
+            updateStep();
+        }
+    }
+
+    void clearToTargetValue() noexcept
+    {
+        mem = target;
+    }
+
+    inline float peek() const noexcept
+    {
+        const float dy = target - mem;
+        return mem + std::copysign(std::fmin(std::abs(dy), std::abs(step)), dy);
+    }
+
+    inline float next() noexcept
+    {
+        const float y0 = mem;
+        const float dy = target - y0;
+        return (mem = y0 + std::copysign(std::fmin(std::abs(dy), std::abs(step)), dy));
+    }
+
+private:
+    void updateStep() noexcept
+    {
+        step = (target - mem) / (tau * sampleRate);
+    }
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+#endif // DISTRHO_VALUE_SMOOTHER_HPP_INCLUDED

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /workdir
+mkdir -p build && cd build \
+&& cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DBUILD_BENCH=ON ../ \
+&& cmake --build . \
+&& make install DESTDIR="/workdir"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.7.2)
+project(examples)
+
+set(CMAKE_CXX_STANDARD 14)
+
+# set optimization flags
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -fPIC -shared -O3 -mcpu=cortex-a8 -mtune=cortex-a8 -mfloat-abi=hard -mfpu=neon -ftree-vectorize -ffast-math -fprefetch-loop-arrays -funroll-loops -funsafe-loop-optimizations -fno-finite-math-only")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,-Ofast -Wl,--as-needed -Wl,--strip-debug")
+message("CMAKE_CXX_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_CXX_FLAGS_RELEASE}")
+message("CMAKE_SHARED_LINKER_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
+
+include_directories(../resources)
+
+include_directories(../common)
+
+# Get all .cpp files in the current directory
+file(GLOB EFFECTS_SRC
+    "*.cpp"
+)
+
+# Compile Biquad.cpp into an object file
+add_library(Biquad OBJECT ../../common/Biquad.cpp)
+
+# Get all directories in the current directory
+file(GLOB EFFECTS_DIRS LIST_DIRECTORIES true RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*")
+
+foreach(EFFECT_DIR ${EFFECTS_DIRS})
+    # Skip if not a directory
+    if(NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${EFFECT_DIR})
+        continue()
+    endif()
+
+    # @TODO: enable when ready
+    # Skip if the directory is 'juce_effect'
+    if(EFFECT_DIR STREQUAL "juce_effect")
+        continue()
+    endif()
+
+    # Get the filename without extension
+    get_filename_component(EFFECT_NAME ${EFFECT_DIR} NAME_WE)
+
+    # If the current file is Equalizer.cpp, link it with Biquad
+    if(EFFECT_NAME STREQUAL "equalizer")
+        add_library(${EFFECT_NAME} SHARED ${EFFECT_DIR}/${EFFECT_NAME}.cpp $<TARGET_OBJECTS:Biquad>)
+    else()
+        add_library(${EFFECT_NAME} SHARED ${EFFECT_DIR}/${EFFECT_NAME}.cpp)
+    endif()
+
+    # Remove the 'lib' prefix from the output library name
+    set_target_properties(${EFFECT_NAME} PROPERTIES PREFIX "")
+
+    # Install the library to the 'bins' directory
+    install(TARGETS ${EFFECT_NAME} LIBRARY DESTINATION bins)
+endforeach(EFFECT_DIR)

--- a/examples/LICENSE.txt
+++ b/examples/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Geraint Luff / Signalsmith Audio Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,119 @@
+# Signalsmith Stretch: C++ pitch/time library
+
+This is a C++11 library for pitch and time stretching, using the final approach from the ADC22 presentation [Four Ways To Write A Pitch-Shifter](https://www.youtube.com/watch?v=fJUmmcGKZMI).
+
+It can handle a wide-range of pitch-shifts (multiple octaves) but time-stretching sounds best for more modest changes (between 0.75x and 1.5x).  There are some audio examples and an interactive web demo on the [main project page](https://signalsmith-audio.co.uk/code/stretch/).
+
+## How to use it
+
+```cpp
+#include "signalsmith-stretch.h"
+
+signalsmith::stretch::SignalsmithStretch<float> stretch;
+```
+
+### Configuring
+
+The easiest way to configure is a `.preset???()` method:
+
+```cpp
+stretch.presetDefault(channels, sampleRate);
+stretch.presetCheaper(channels, sampleRate);
+```
+
+If you want to try out different block sizes for yourself. you can use `.configure()` manually:
+
+```cpp
+stretch.configure(channels, blockSamples, intervalSamples);
+
+// query the current configuration
+int block = stretch.blockSamples();
+int interval = stretch.intervalSamples();
+```
+
+### Processing and resetting
+
+To process a block, call `.process()`:
+
+```cpp
+float **inputBuffers, **outputBuffers;
+int inputSamples, outputSamples;
+stretch.process(inputBuffers, inputSamples, outputBuffers, outputSamples);
+```
+
+The input/output buffers cannot be the same, but they can be any type where `buffer[channel][index]` gives you a sample.  This might be `float **` or a `double **` or some custom object (e.g. providing access to an interleaved buffer), regardless of what sample-type the stretcher is using internally.
+
+To clear the internal buffers:
+
+```cpp
+stretch.reset();
+```
+
+### Pitch-shifting
+
+```cpp
+stretch.setTransposeFactor(2); // up one octave
+
+stretch.setTransposeSemitones(12); // also one octave
+```
+
+You can set a "tonality limit", which uses a non-linear frequency map to preserve a bit more of the timbre:
+
+```cpp
+stretch.setTransposeSemitones(4, 8000/sampleRate);
+```
+
+Alternatively, you can set a custom frequency map, mapping input frequencies to output frequencies (both normalised against the sample-rate): 
+
+```cpp
+stretch.setFreqMap([](float inputFreq) {
+	return inputFreq*2; // up one octave
+});
+```
+
+### Time-stretching
+
+To get a time-stretch, hand differently-sized input/output buffers to .process(). There's no maximum block size for either input or output.
+
+Since the buffer lengths (inputSamples and outputSamples above) are integers, it's up to you to make sure that the block lengths average out to the ratio you want over time.
+
+### Latency
+
+Latency is particularly ambiguous for a time-stretching effect. We report the latency in two halves:
+
+```cpp
+int inputLatency = stretch.inputLatency();
+int outputLatency = stretch.outputLatency();
+```
+
+You should be supplying input samples slightly ahead of the processing time (which is where changes to pitch-shift or stretch rate will be centred), and you'll receive output samples slightly behind that processing time.
+
+#### Automation
+
+To follow pitch/time automation accurately, you should give it automation values from the current processing time (`.outputLatency()` samples ahead of the output), and feed it input from `.inputLatency()` samples ahead of the current processing time.
+
+#### Starting and ending
+
+After initialisation/reset to zero, the current processing time is `.inputLatency()` samples *before* t=0 in the input. This means you'll get `stretch.outputLatency() + stretch.inputLatency()*stretchFactor` samples of pre-roll output in total.
+
+If you're processing a fixed-length sound (instead of an infinite stream), you'll end up providing `.inputLatency()` samples of extra (zero) input at the end, to get the processing time to the right place. You'll then want to give it another `.outputLatency()` samples of (zero) input to fully clear the buffer, producing a correspondly-stretched amount of output.
+
+What you do with this extra start/end output is up to you. Personally, I'd try inverting the phase and reversing them in time, and then adding them to the start/end of the result. (Wrapping this up in a helper function is on the TODO list.)
+
+## Compiling
+
+⚠️ This has mostly been tested with Clang. If you're using another compiler and have any problems, please get in touch.
+
+Just include `signalsmith-stretch.h` where needed.
+
+It's much slower (about 10x) if optimisation is disabled though, so you might want to enable optimisation where it's used, even in debug builds.
+
+### DSP Library
+
+This uses the Signalsmith DSP library for FFTs and other bits and bobs.
+
+For convenience, a copy of the library is included (with its own `LICENSE.txt`) in `dsp/`, but if you're already using this elsewhere then you should remove this copy to avoid versioning issues.
+
+## License
+
+[MIT License](LICENSE.txt) for now - get in touch if you need anything else.

--- a/examples/dsp.hpp
+++ b/examples/dsp.hpp
@@ -1,0 +1,117 @@
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <math.h>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+#define MAXKNOBS 10
+#define MAXSWITCHES 5
+
+#ifndef Uint
+typedef unsigned int Uint;
+#endif
+
+struct dsp {
+	enum SWITCH_STATE{
+		UP = 0,
+		DOWN = 1,
+		MIDDLE = 2
+	};
+    private:
+
+	protected:
+		std::string version;
+    
+    public:
+		int fSampleRate = 44100;
+		float knobs[MAXKNOBS];
+		SWITCH_STATE switches[MAXSWITCHES];
+		SWITCH_STATE stompSwitch;
+		std::string name;
+		
+        dsp() {
+        	name = "null";
+        	for(int i=0;i<MAXKNOBS;++i)
+        		knobs[i]=.5;
+        	for(int i=0;i<MAXSWITCHES;++i)
+        		switches[i]=SWITCH_STATE::DOWN;
+        	stompSwitch = DOWN;
+        }
+        ~dsp() {}
+	
+	//Use for switch debugging
+	//static const int SWITCH_STATES = 3;
+    //const char* swStates[SWITCH_STATES] = {"UP", "MIDDLE", "DOWN"};
+
+	void getTextForEnum(SWITCH_STATE enumVal, std::string *out){
+		if(enumVal == 0)//SWITCH_STATE::UP)
+			*out = "UP";
+		else if(enumVal == 1)//SWITCH_STATE::MIDDLE)
+			*out = "MIDDLE";
+		else if(enumVal == 2)//SWITCH_STATE::DOWN)
+			*out = "DOWN";
+		else
+			*out = "BAD";
+		return;
+	}
+
+	void setName(std::string name){
+		this->name=name;
+	}
+	
+	std::string getName(){
+		return name;
+	}
+	
+	std::string getVersion(){
+		return version;
+	}
+
+	virtual void setKnob(int num, float knobVal){
+		this->knobs[num] = knobVal;
+	}
+	
+	virtual float getKnob(int in){
+		return knobs[in];
+	}
+	
+	virtual void setSwitch(int num, SWITCH_STATE switchVal){
+		switches[num] = switchVal;
+	}
+	
+	virtual SWITCH_STATE getSwitch(int in){
+		return switches[in];
+	}
+
+	virtual void setStompSwitch(SWITCH_STATE switchVal){
+		stompSwitch=switchVal;
+	}
+	
+	virtual bool getStompSwitch(){
+		return stompSwitch;
+	}
+	
+	virtual void stompSwitchPressed(int count, FAUSTFLOAT* inputs, FAUSTFLOAT* outputs){
+		if(stompSwitch){
+			compute(count, inputs, outputs);
+		}
+		return;
+	}
+	
+	virtual void instanceConstants() = 0;
+
+	virtual void compute(int count, FAUSTFLOAT* inputs, FAUSTFLOAT* outputs) = 0;
+};
+
+#endif
+
+
+
+using dsp_creator_t = dsp *(*)();

--- a/examples/dsp/LICENSE.txt
+++ b/examples/dsp/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Geraint Luff / Signalsmith Audio Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/dsp/README.md
+++ b/examples/dsp/README.md
@@ -1,0 +1,40 @@
+# Signalsmith Audio's DSP Library
+
+A C++11 header-only library, providing classes/templates for (mostly audio) signal-processing tasks.
+
+More detail is in the [main project page](https://signalsmith-audio.co.uk/code/dsp/), and the [Doxygen docs](https://signalsmith-audio.co.uk/code/dsp/html/modules.html).
+
+## Basic use
+
+```
+git clone https://signalsmith-audio.co.uk/code/dsp.git
+```
+
+Just include the header file(s) you need, and start using classes:
+
+```cpp
+#include "dsp/delay.h"
+
+using Delay = signalsmith::delay::Delay<float>;
+Delay delayLine(1024);
+```
+
+You can add a compile-time version-check to make sure you have a compatible version of the library:
+```cpp
+#include "dsp/envelopes.h"
+SIGNALSMITH_DSP_VERSION_CHECK(1, 6, 0)
+```
+
+### Development / contributing
+
+Tests (and source-scripts for the above docs) are available in a separate repo:
+
+```
+git clone https://signalsmith-audio.co.uk/code/dsp-doc.git
+```
+
+The goal (where possible) is to measure/test the actual audio characteristics of the tools (e.g. frequency responses and aliasing levels).
+
+### License
+
+This code is [MIT licensed](LICENSE.txt).  If you'd prefer something else, get in touch.

--- a/examples/dsp/common.h
+++ b/examples/dsp/common.h
@@ -1,0 +1,43 @@
+#ifndef SIGNALSMITH_DSP_COMMON_H
+#define SIGNALSMITH_DSP_COMMON_H
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338327950288
+#endif
+
+namespace signalsmith {
+	/**	@defgroup Common Common
+		@brief Definitions and helper classes used by the rest of the library
+		
+		@{
+		@file
+	*/
+
+#define SIGNALSMITH_DSP_VERSION_MAJOR 1
+#define SIGNALSMITH_DSP_VERSION_MINOR 6
+#define SIGNALSMITH_DSP_VERSION_PATCH 0
+#define SIGNALSMITH_DSP_VERSION_STRING "1.6.0"
+
+	/** Version compatability check.
+	\code{.cpp}
+		static_assert(signalsmith::version(1, 4, 1), "version check");
+	\endcode
+	... or use the equivalent `SIGNALSMITH_DSP_VERSION_CHECK`.
+	Major versions are not compatible with each other.  Minor and patch versions are backwards-compatible.
+	*/
+	constexpr bool versionCheck(int major, int minor, int patch=0) {
+		return major == SIGNALSMITH_DSP_VERSION_MAJOR
+			&& (SIGNALSMITH_DSP_VERSION_MINOR > minor
+				|| (SIGNALSMITH_DSP_VERSION_MINOR == minor && SIGNALSMITH_DSP_VERSION_PATCH >= patch));
+	}
+
+/// Check the library version is compatible (semver).
+#define SIGNALSMITH_DSP_VERSION_CHECK(major, minor, patch) \
+	static_assert(::signalsmith::versionCheck(major, minor, patch), "signalsmith library version is " SIGNALSMITH_DSP_VERSION_STRING);
+
+/** @} */
+} // signalsmith::
+#else
+// If we've already included it, check it's the same version
+static_assert(SIGNALSMITH_DSP_VERSION_MAJOR == 1 && SIGNALSMITH_DSP_VERSION_MINOR == 6 && SIGNALSMITH_DSP_VERSION_PATCH == 0, "multiple versions of the Signalsmith DSP library");
+#endif // include guard

--- a/examples/dsp/curves.h
+++ b/examples/dsp/curves.h
@@ -1,0 +1,371 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_CURVES_H
+#define SIGNALSMITH_DSP_CURVES_H
+
+#include <vector>
+#include <algorithm> // std::stable_sort
+
+namespace signalsmith {
+namespace curves {
+	/**	@defgroup Curves Curves
+		@brief User-defined mapping functions
+		
+		@{
+		@file
+	*/
+
+	/// Linear map for real values.
+	template<typename Sample=double>
+	class Linear {
+		Sample a1, a0;
+	public:
+		Linear() : Linear(0, 1) {}
+		Linear(Sample a0, Sample a1) : a1(a1), a0(a0) {}
+		/// Construct by from/to value pairs
+		Linear(Sample x0, Sample x1, Sample y0, Sample y1) : a1((x0 == x1) ? 0 : (y1 - y0)/(x1 - x0)), a0(y0 - x0*a1) {}
+
+		Sample operator ()(Sample x) const {
+			return a0 + x*a1;
+		}
+		
+		Sample dx() const {
+			return a1;
+		}
+		
+		/// Returns the inverse map (with some numerical error)
+		Linear inverse() const {
+			Sample invA1 = 1/a1;
+			return Linear(-a0*invA1, invA1);
+		}
+	};
+
+	/// A real-valued cubic curve.  It has a "start" point where accuracy is highest.
+	template<typename Sample=double>
+	class Cubic {
+		Sample xStart, a0, a1, a2, a3;
+		
+		// Only use with y0 != y1
+		static inline Sample gradient(Sample x0, Sample x1, Sample y0, Sample y1) {
+			return (y1 - y0)/(x1 - x0);
+		}
+		// Ensure a gradient produces monotonic segments
+		static inline void ensureMonotonic(Sample &curveGrad, Sample gradA, Sample gradB) {
+			if ((gradA <= 0 && gradB >= 0) || (gradA >= 0 && gradB <= 0)) {
+				curveGrad = 0; // point is a local minimum/maximum
+			} else {
+				if (std::abs(curveGrad) > std::abs(gradA*3)) {
+					curveGrad = gradA*3;
+				}
+				if (std::abs(curveGrad) > std::abs(gradB*3)) {
+					curveGrad = gradB*3;
+				}
+			}
+		}
+		// When we have duplicate x-values (either side) make up a gradient
+		static inline void chooseGradient(Sample &curveGrad, Sample grad1, Sample curveGradOther, Sample y0, Sample y1, bool monotonic) {
+			curveGrad = 2*grad1 - curveGradOther;
+			if (y0 != y1 && (y1 > y0) != (grad1 >= 0)) { // not duplicate y, but a local min/max
+				curveGrad = 0;
+			} else if (monotonic) {
+				if (grad1 >= 0) {
+					curveGrad = std::max<Sample>(0, curveGrad);
+				} else {
+					curveGrad = std::min<Sample>(0, curveGrad);
+				}
+			}
+		}
+	public:
+		Cubic() : Cubic(0, 0, 0, 0, 0) {}
+		Cubic(Sample xStart, Sample a0, Sample a1, Sample a2, Sample a3) : xStart(xStart), a0(a0), a1(a1), a2(a2), a3(a3) {}
+		
+		Sample operator ()(Sample x) const {
+			x -= xStart;
+			return a0 + x*(a1 + x*(a2 + x*a3));
+		}
+		/// The reference x-value, used as the centre of the cubic expansion
+		Sample start() const {
+			return xStart;
+		}
+		/// Differentiate
+		Cubic dx() const {
+			return {xStart, a1, 2*a2, 3*a3, 0};
+		}
+		Sample dx(Sample x) const {
+			x -= xStart;
+			return a1 + x*(2*a2 + x*(3*a3));
+		}
+		
+		/// Cubic segment based on start/end values and gradients
+		static Cubic hermite(Sample x0, Sample x1, Sample y0, Sample y1, Sample g0, Sample g1) {
+			Sample xScale = 1/(x1 - x0);
+			return {
+				x0, y0, g0,
+				(3*(y1 - y0)*xScale - 2*g0 - g1)*xScale,
+				(2*(y0 - y1)*xScale + g0 + g1)*(xScale*xScale)
+			};
+		}
+		
+		/** Cubic segment (valid between `x1` and `x2`), which is smooth when applied to an adjacent set of points.
+		If `x0 == x1` or `x2 == x3` it will choose a gradient which continues in a quadratic curve, or 0 if the point is a local minimum/maximum.
+		*/
+		static Cubic smooth(Sample x0, Sample x1, Sample x2, Sample x3, Sample y0, Sample y1, Sample y2, Sample y3, bool monotonic=false) {
+			if (x1 == x2) return {0, y1, 0, 0, 0}; // zero-width segment, just return constant
+
+			Sample grad1 = gradient(x1, x2, y1, y2);
+			Sample curveGrad1 = grad1;
+			bool chooseGrad1 = false;
+			if (x0 != x1) { // we have a defined x0-x1 gradient
+				Sample grad0 = gradient(x0, x1, y0, y1);
+				curveGrad1 = (grad0 + grad1)*Sample(0.5);
+				if (monotonic) ensureMonotonic(curveGrad1, grad0, grad1);
+			} else if (y0 != y1 && (y1 > y0) != (grad1 >= 0)) {
+				curveGrad1 = 0; // set to 0 if it's a min/max
+			} else {
+				curveGrad1 = 0;
+				chooseGrad1 = true;
+			}
+			Sample curveGrad2;
+			if (x2 != x3) { // we have a defined x1-x2 gradient
+				Sample grad2 = gradient(x2, x3, y2, y3);
+				curveGrad2 = (grad1 + grad2)*Sample(0.5);
+				if (monotonic) ensureMonotonic(curveGrad2, grad1, grad2);
+			} else {
+				chooseGradient(curveGrad2, grad1, curveGrad1, y2, y3, monotonic);
+			}
+			if (chooseGrad1) {
+				chooseGradient(curveGrad1, grad1, curveGrad2, y0, y1, monotonic);
+			}
+			return hermite(x1, x2, y1, y2, curveGrad1, curveGrad2);
+		}
+	};
+	
+	/** Smooth interpolation (optionally monotonic) between points, using cubic segments.
+	\diagram{cubic-segments-example.svg,Example curve including a repeated point and an instantaneous jump.  The curve is flat beyond the first/last points.}
+	To produce a sharp corner, use a repeated point. The gradient is flat at the edges, unless you use repeated points at the start/end.*/
+	template<typename Sample=double>
+	class CubicSegmentCurve {
+		struct Point {
+			Sample x, y;
+			Sample lineGrad = 0, curveGrad = 0;
+			bool hasCurveGrad = false;
+
+			Point() : Point(0, 0) {}
+			Point(Sample x, Sample y) : x(x), y(y) {}
+
+			bool operator <(const Point &other) const {
+				return x < other.x;
+			}
+		};
+		std::vector<Point> points;
+		Point first{0, 0}, last{0, 0};
+		
+		std::vector<Cubic<Sample>> _segments{1};
+		// Not public because it's only valid inside the bounds
+		const Cubic<Sample> & findSegment(Sample x) const {
+			// Binary search
+			size_t low = 0, high = _segments.size();
+			while (true) {
+				size_t mid = (low + high)/2;
+				if (low == mid) break;
+				if (_segments[mid].start() <= x) {
+					low = mid;
+				} else {
+					high = mid;
+				}
+			}
+			return _segments[low];
+		}
+	public:
+		Sample lowGrad = 0;
+		Sample highGrad = 0;
+	
+		/// Clear existing points and segments
+		void clear() {
+			points.resize(0);
+			_segments.resize(0);
+			first = last = {0, 0};
+		}
+	
+		/// Add a new point, but does not recalculate the segments.  `corner` just writes the point twice, for convenience.
+		CubicSegmentCurve & add(Sample x, Sample y, bool corner=false) {
+			points.push_back({x, y});
+			if (corner) points.push_back({x, y});
+			return *this;
+		}
+		
+		/// Recalculates the segments.
+		void update(bool monotonic=false, bool extendGrad=true, Sample monotonicFactor=3) {
+			if (points.empty()) add(0, 0);
+			std::stable_sort(points.begin(), points.end()); // Ensure ascending order
+			_segments.resize(0);
+
+			// Calculate the point-to-point gradients
+			for (size_t i = 1; i < points.size(); ++i) {
+				auto &prev = points[i - 1];
+				auto &next = points[i];
+				if (prev.x != next.x) {
+					prev.lineGrad = (next.y - prev.y)/(next.x - prev.x);
+				} else {
+					prev.lineGrad = 0;
+				}
+			}
+
+			for (auto &p : points) p.hasCurveGrad = false;
+			points[0].curveGrad = lowGrad;
+			points[0].hasCurveGrad = true;
+			points.back().curveGrad = highGrad;
+			points.back().hasCurveGrad = true;
+
+			// Calculate curve gradient where we know it
+			for (size_t i = 1; i + 1 < points.size(); ++i) {
+				auto &p0 = points[i - 1];
+				auto &p1 = points[i];
+				auto &p2 = points[i + 1];
+				if (p0.x != p1.x && p1.x != p2.x) {
+					p1.curveGrad = (p0.lineGrad + p1.lineGrad)*Sample(0.5);
+					p1.hasCurveGrad = true;
+				}
+			}
+			
+			for (size_t i = 1; i < points.size(); ++i) {
+				Point &p1 = points[i - 1];
+				Point &p2 = points[i];
+				if (p1.x == p2.x) continue;
+				if (p1.hasCurveGrad) {
+					if (!p2.hasCurveGrad) {
+						p2.curveGrad = 2*p1.lineGrad - p1.curveGrad;
+					}
+				} else if (p2.hasCurveGrad) {
+					p1.curveGrad = 2*p1.lineGrad - p2.curveGrad;
+				} else {
+					p1.curveGrad = p2.curveGrad = p1.lineGrad;
+				}
+			}
+
+			if (monotonic) {
+				for (size_t i = 1; i < points.size(); ++i) {
+					Point &p1 = points[i - 1];
+					Point &p2 = points[i];
+					if (p1.x != p2.x) {
+						if (p1.lineGrad >= 0) {
+							p1.curveGrad = std::max<Sample>(0, std::min(p1.curveGrad, p1.lineGrad*monotonicFactor));
+							p2.curveGrad = std::max<Sample>(0, std::min(p2.curveGrad, p1.lineGrad*monotonicFactor));
+						} else {
+							p1.curveGrad = std::min<Sample>(0, std::max(p1.curveGrad, p1.lineGrad*monotonicFactor));
+							p2.curveGrad = std::min<Sample>(0, std::max(p2.curveGrad, p1.lineGrad*monotonicFactor));
+						}
+					}
+				}
+			}
+
+			for (size_t i = 1; i < points.size(); ++i) {
+				Point &p1 = points[i - 1];
+				Point &p2 = points[i];
+				if (p1.x != p2.x) {
+					_segments.push_back(Segment::hermite(p1.x, p2.x, p1.y, p2.y, p1.curveGrad, p2.curveGrad));
+				}
+			}
+			
+			first = points[0];
+			last = points.back();
+			if (extendGrad && _segments.size()) {
+				if (points[0].x != points[1].x || points[0].y == points[1].y) {
+					lowGrad = _segments[0].dx(first.x);
+				}
+				auto &last = points.back(), &last2 = points[points.size() - 1];
+				if (last.x != last2.x || last.y == last2.y) {
+					highGrad = _segments.back().dx(last.x);
+				}
+			}
+		}
+		
+		/// Reads a value out from the curve.
+		Sample operator()(Sample x) const {
+			if (x <= first.x) return first.y + (x - first.x)*lowGrad;
+			if (x >= last.x) return last.y + (x - last.x)*highGrad;
+			return findSegment(x)(x);
+		}
+
+		CubicSegmentCurve dx() const {
+			CubicSegmentCurve result{*this};
+			result.first.y = lowGrad;
+			result.last.y = highGrad;
+			result.lowGrad = result.highGrad = 0;
+			for (auto &s : result._segments) {
+				s = s.dx();
+			}
+			return result;
+		}
+		Sample dx(Sample x) const {
+			if (x < first.x) return lowGrad;
+			if (x >= last.x) return highGrad;
+			return findSegment(x).dx(x);
+		}
+
+		using Segment = Cubic<Sample>;
+		std::vector<Segment> & segments() {
+			return _segments;
+		}
+		const std::vector<Segment> & segments() const {
+			return _segments;
+		}
+	};
+	
+	/** A warped-range map, based on 1/x
+		\diagram{curves-reciprocal-example.svg}*/
+	template<typename Sample=double>
+	class Reciprocal {
+		Sample a, b, c, d; // (a + bx)/(c + dx)
+		Reciprocal(Sample a, Sample b, Sample c, Sample d) : a(a), b(b), c(c), d(d) {}
+	public:
+		/** Decent approximation to the Bark scale
+ 
+		The Bark index goes from 1-24, but this map is valid from approximately 0.25 - 27.5.
+		You can get the bandwidth by `barkScale.dx(barkIndex)`.
+		\diagram{curves-reciprocal-approx-bark.svg}*/
+		static Reciprocal<Sample> barkScale() {
+			return {1, 10, 24, 60, 1170, 13500};
+		}
+		/// Returns a map from 0-1 to the given (non-negative) Hz range.
+		static Reciprocal<Sample> barkRange(Sample lowHz, Sample highHz) {
+			Reciprocal bark = barkScale();
+			Sample lowBark = bark.inverse(lowHz), highBark = bark.inverse(highHz);
+			return Reciprocal(lowBark, (lowBark + highBark)/2, highBark).then(bark);
+		}
+
+		Reciprocal() : Reciprocal(0, 0.5, 1) {}
+		/// If no x-range given, default to the unit range
+		Reciprocal(Sample y0, Sample y1, Sample y2) : Reciprocal(0, 0.5, 1, y0, y1, y2) {}
+		Reciprocal(Sample x0, Sample x1, Sample x2, Sample y0, Sample y1, Sample y2) {
+			Sample kx = (x1 - x0)/(x2 - x1);
+			Sample ky = (y1 - y0)/(y2 - y1);
+			a = (kx*x2)*y0 - (ky*x0)*y2;
+			b = ky*y2 - kx*y0;
+			c = kx*x2 - ky*x0;
+			d = ky - kx;
+		}
+
+		Sample operator ()(double x) const {
+			return (a + b*x)/(c + d*x);
+		}
+		Reciprocal inverse() const {
+			return Reciprocal(-a, c, b, -d);
+		}
+		Sample inverse(Sample y) const {
+			return (c*y - a)/(b - d*y);
+		}
+		Sample dx(Sample x) const {
+			Sample l = (c + d*x);
+			return (b*c - a*d)/(l*l);
+		}
+		
+		/// Combine two `Reciprocal`s together in sequence
+		Reciprocal then(const Reciprocal &other) const {
+			return Reciprocal(other.a*c + other.b*a, other.a*d + other.b*b, other.c*c + other.d*a, other.c*d + other.d*b);
+		}
+	};
+	
+/** @} */
+}} // namespace
+#endif // include guard

--- a/examples/dsp/delay.h
+++ b/examples/dsp/delay.h
@@ -1,0 +1,717 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_DELAY_H
+#define SIGNALSMITH_DSP_DELAY_H
+
+#include <vector>
+#include <array>
+#include <cmath> // for std::ceil()
+#include <type_traits>
+
+#include <complex>
+#include "./fft.h"
+#include "./windows.h"
+
+namespace signalsmith {
+namespace delay {
+	/**	@defgroup Delay Delay utilities
+		@brief Standalone templated classes for delays
+		
+		You can set up a `Buffer` or `MultiBuffer`, and get interpolated samples using a `Reader` (separately on each channel in the multi-channel case) - or you can use `Delay`/`MultiDelay` which include their own buffers.
+
+		Interpolation quality is chosen using a template class, from @ref Interpolators.
+
+		@{
+		@file
+	*/
+
+	/** @brief Single-channel delay buffer
+ 
+		Access is used with `buffer[]`, relative to the internal read/write position ("head").  This head is moved using `++buffer` (or `buffer += n`), such that `buffer[1] == (buffer + 1)[0]` in a similar way iterators/pointers.
+		
+		Operations like `buffer - 10` or `buffer++` return a View, which holds a fixed position in the buffer (based on the read/write position at the time).
+		
+		The capacity includes both positive and negative indices.  For example, a capacity of 100 would support using any of the ranges:
+		
+		* `buffer[-99]` to buffer[0]`
+		* `buffer[-50]` to buffer[49]`
+		* `buffer[0]` to buffer[99]`
+
+		Although buffers are usually used with historical samples accessed using negative indices e.g. `buffer[-10]`, you could equally use it flipped around (moving the head backwards through the buffer using `--buffer`).
+	*/
+	template<typename Sample>
+	class Buffer {
+		unsigned bufferIndex;
+		unsigned bufferMask;
+		std::vector<Sample> buffer;
+	public:
+		Buffer(int minCapacity=0) {
+			resize(minCapacity);
+		}
+		// We shouldn't accidentally copy a delay buffer
+		Buffer(const Buffer &other) = delete;
+		Buffer & operator =(const Buffer &other) = delete;
+		// But moving one is fine
+		Buffer(Buffer &&other) = default;
+		Buffer & operator =(Buffer &&other) = default;
+
+		void resize(int minCapacity, Sample value=Sample()) {
+			int bufferLength = 1;
+			while (bufferLength < minCapacity) bufferLength *= 2;
+			buffer.assign(bufferLength, value);
+			bufferMask = unsigned(bufferLength - 1);
+			bufferIndex = 0;
+		}
+		void reset(Sample value=Sample()) {
+			buffer.assign(buffer.size(), value);
+		}
+
+		/// Holds a view for a particular position in the buffer
+		template<bool isConst>
+		class View {
+			using CBuffer = typename std::conditional<isConst, const Buffer, Buffer>::type;
+			using CSample = typename std::conditional<isConst, const Sample, Sample>::type;
+			CBuffer *buffer = nullptr;
+			unsigned bufferIndex = 0;
+		public:
+			View(CBuffer &buffer, int offset=0) : buffer(&buffer), bufferIndex(buffer.bufferIndex + (unsigned)offset) {}
+			View(const View &other, int offset=0) : buffer(other.buffer), bufferIndex(other.bufferIndex + (unsigned)offset) {}
+			View & operator =(const View &other) {
+				buffer = other.buffer;
+				bufferIndex = other.bufferIndex;
+				return *this;
+			}
+			
+			CSample & operator[](int offset) {
+				return buffer->buffer[(bufferIndex + (unsigned)offset)&buffer->bufferMask];
+			}
+			const Sample & operator[](int offset) const {
+				return buffer->buffer[(bufferIndex + (unsigned)offset)&buffer->bufferMask];
+			}
+
+			/// Write data into the buffer
+			template<typename Data>
+			void write(Data &&data, int length) {
+				for (int i = 0; i < length; ++i) {
+					(*this)[i] = data[i];
+				}
+			}
+			/// Read data out from the buffer
+			template<typename Data>
+			void read(int length, Data &&data) const {
+				for (int i = 0; i < length; ++i) {
+					data[i] = (*this)[i];
+				}
+			}
+
+			View operator +(int offset) const {
+				return View(*this, offset);
+			}
+			View operator -(int offset) const {
+				return View(*this, -offset);
+			}
+		};
+		using MutableView = View<false>;
+		using ConstView = View<true>;
+		
+		MutableView view(int offset=0) {
+			return MutableView(*this, offset);
+		}
+		ConstView view(int offset=0) const {
+			return ConstView(*this, offset);
+		}
+		ConstView constView(int offset=0) const {
+			return ConstView(*this, offset);
+		}
+
+		Sample & operator[](int offset) {
+			return buffer[(bufferIndex + (unsigned)offset)&bufferMask];
+		}
+		const Sample & operator[](int offset) const {
+			return buffer[(bufferIndex + (unsigned)offset)&bufferMask];
+		}
+
+		/// Write data into the buffer
+		template<typename Data>
+		void write(Data &&data, int length) {
+			for (int i = 0; i < length; ++i) {
+				(*this)[i] = data[i];
+			}
+		}
+		/// Read data out from the buffer
+		template<typename Data>
+		void read(int length, Data &&data) const {
+			for (int i = 0; i < length; ++i) {
+				data[i] = (*this)[i];
+			}
+		}
+		
+		Buffer & operator ++() {
+			++bufferIndex;
+			return *this;
+		}
+		Buffer & operator +=(int i) {
+			bufferIndex += (unsigned)i;
+			return *this;
+		}
+		Buffer & operator --() {
+			--bufferIndex;
+			return *this;
+		}
+		Buffer & operator -=(int i) {
+			bufferIndex -= (unsigned)i;
+			return *this;
+		}
+
+		MutableView operator ++(int) {
+			MutableView view(*this);
+			++bufferIndex;
+			return view;
+		}
+		MutableView operator +(int i) {
+			return MutableView(*this, i);
+		}
+		ConstView operator +(int i) const {
+			return ConstView(*this, i);
+		}
+		MutableView operator --(int) {
+			MutableView view(*this);
+			--bufferIndex;
+			return view;
+		}
+		MutableView operator -(int i) {
+			return MutableView(*this, -i);
+		}
+		ConstView operator -(int i) const {
+			return ConstView(*this, -i);
+		}
+	};
+
+	/** @brief Multi-channel delay buffer
+
+		This behaves similarly to the single-channel `Buffer`, with the following differences:
+		
+		* `buffer[c]` returns a view for a single channel, which behaves like the single-channel `Buffer::View`.
+		* The constructor and `.resize()` take an additional first `channel` argument.
+	*/
+	template<typename Sample>
+	class MultiBuffer {
+		int channels, stride;
+		Buffer<Sample> buffer;
+	public:
+		using ConstChannel = typename Buffer<Sample>::ConstView;
+		using MutableChannel = typename Buffer<Sample>::MutableView;
+
+		MultiBuffer(int channels=0, int capacity=0) : channels(channels), stride(capacity), buffer(channels*capacity) {}
+
+		void resize(int nChannels, int capacity, Sample value=Sample()) {
+			channels = nChannels;
+			stride = capacity;
+			buffer.resize(channels*capacity, value);
+		}
+		void reset(Sample value=Sample()) {
+			buffer.reset(value);
+		}
+
+		/// A reference-like multi-channel result for a particular sample index
+		template<bool isConst>
+		class Stride {
+			using CChannel = typename std::conditional<isConst, ConstChannel, MutableChannel>::type;
+			using CSample = typename std::conditional<isConst, const Sample, Sample>::type;
+			CChannel view;
+			int channels, stride;
+		public:
+			Stride(CChannel view, int channels, int stride) : view(view), channels(channels), stride(stride) {}
+			Stride(const Stride &other) : view(other.view), channels(other.channels), stride(other.stride) {}
+			
+			CSample & operator[](int channel) {
+				return view[channel*stride];
+			}
+			const Sample & operator[](int channel) const {
+				return view[channel*stride];
+			}
+
+			/// Reads from the buffer into a multi-channel result
+			template<class Data>
+			void get(Data &&result) const {
+				for (int c = 0; c < channels; ++c) {
+					result[c] = view[c*stride];
+				}
+			}
+			/// Writes from multi-channel data into the buffer
+			template<class Data>
+			void set(Data &&data) {
+				for (int c = 0; c < channels; ++c) {
+					view[c*stride] = data[c];
+				}
+			}
+			template<class Data>
+			Stride & operator =(const Data &data) {
+				set(data);
+				return *this;
+			}
+			Stride & operator =(const Stride &data) {
+				set(data);
+				return *this;
+			}
+		};
+		
+		Stride<false> at(int offset) {
+			return {buffer.view(offset), channels, stride};
+		}
+		Stride<true> at(int offset) const {
+			return {buffer.view(offset), channels, stride};
+		}
+
+		/// Holds a particular position in the buffer
+		template<bool isConst>
+		class View {
+			using CChannel = typename std::conditional<isConst, ConstChannel, MutableChannel>::type;
+			CChannel view;
+			int channels, stride;
+		public:
+			View(CChannel view, int channels, int stride) : view(view), channels(channels), stride(stride) {}
+			
+			CChannel operator[](int channel) {
+				return view + channel*stride;
+			}
+			ConstChannel operator[](int channel) const {
+				return view + channel*stride;
+			}
+
+			Stride<isConst> at(int offset) {
+				return {view + offset, channels, stride};
+			}
+			Stride<true> at(int offset) const {
+				return {view + offset, channels, stride};
+			}
+		};
+		using MutableView = View<false>;
+		using ConstView = View<true>;
+
+		MutableView view(int offset=0) {
+			return MutableView(buffer.view(offset), channels, stride);
+		}
+		ConstView view(int offset=0) const {
+			return ConstView(buffer.view(offset), channels, stride);
+		}
+		ConstView constView(int offset=0) const {
+			return ConstView(buffer.view(offset), channels, stride);
+		}
+
+		MutableChannel operator[](int channel) {
+			return buffer + channel*stride;
+		}
+		ConstChannel operator[](int channel) const {
+			return buffer + channel*stride;
+		}
+		
+		MultiBuffer & operator ++() {
+			++buffer;
+			return *this;
+		}
+		MultiBuffer & operator +=(int i) {
+			buffer += i;
+			return *this;
+		}
+		MutableView operator ++(int) {
+			return MutableView(buffer++, channels, stride);
+		}
+		MutableView operator +(int i) {
+			return MutableView(buffer + i, channels, stride);
+		}
+		ConstView operator +(int i) const {
+			return ConstView(buffer + i, channels, stride);
+		}
+		MultiBuffer & operator --() {
+			--buffer;
+			return *this;
+		}
+		MultiBuffer & operator -=(int i) {
+			buffer -= i;
+			return *this;
+		}
+		MutableView operator --(int) {
+			return MutableView(buffer--, channels, stride);
+		}
+		MutableView operator -(int i) {
+			return MutableView(buffer - i, channels, stride);
+		}
+		ConstView operator -(int i) const {
+			return ConstView(buffer - i, channels, stride);
+		}
+	};
+	
+	/** \defgroup Interpolators Interpolators
+		\ingroup Delay
+		@{ */
+	/// Nearest-neighbour interpolator
+	/// \diagram{delay-random-access-nearest.svg,aliasing and maximum amplitude/delay errors for different input frequencies}
+	template<typename Sample>
+	struct InterpolatorNearest {
+		static constexpr int inputLength = 1;
+		static constexpr Sample latency = -0.5; // Because we're truncating, which rounds down too often
+	
+		template<class Data>
+		static Sample fractional(const Data &data, Sample) {
+			return data[0];
+		}
+	};
+	/// Linear interpolator
+	/// \diagram{delay-random-access-linear.svg,aliasing and maximum amplitude/delay errors for different input frequencies}
+	template<typename Sample>
+	struct InterpolatorLinear {
+		static constexpr int inputLength = 2;
+		static constexpr int latency = 0;
+	
+		template<class Data>
+		static Sample fractional(const Data &data, Sample fractional) {
+			Sample a = data[0], b = data[1];
+			return a + fractional*(b - a);
+		}
+	};
+	/// Spline cubic interpolator
+	/// \diagram{delay-random-access-cubic.svg,aliasing and maximum amplitude/delay errors for different input frequencies}
+	template<typename Sample>
+	struct InterpolatorCubic {
+		static constexpr int inputLength = 4;
+		static constexpr int latency = 1;
+	
+		template<class Data>
+		static Sample fractional(const Data &data, Sample fractional) {
+			// Cubic interpolation
+			Sample a = data[0], b = data[1], c = data[2], d = data[3];
+			Sample cbDiff = c - b;
+			Sample k1 = (c - a)*0.5;
+			Sample k3 = k1 + (d - b)*0.5 - cbDiff*2;
+			Sample k2 = cbDiff - k3 - k1;
+			return b + fractional*(k1 + fractional*(k2 + fractional*k3)); // 16 ops total, not including the indexing
+		}
+	};
+
+	// Efficient Algorithms and Structures for Fractional Delay Filtering Based on Lagrange Interpolation
+	// Franck 2009 https://www.aes.org/e-lib/browse.cfm?elib=14647
+	namespace _franck_impl {
+		template<typename Sample, int n, int low, int high>
+		struct ProductRange {
+			using Array = std::array<Sample, (n + 1)>;
+			static constexpr int mid = (low + high)/2;
+			using Left = ProductRange<Sample, n, low, mid>;
+			using Right = ProductRange<Sample, n, mid + 1, high>;
+
+			Left left;
+			Right right;
+
+			const Sample total;
+			ProductRange(Sample x) : left(x), right(x), total(left.total*right.total) {}
+
+			template<class Data>
+			Sample calculateResult(Sample extraFactor, const Data &data, const Array &invFactors) {
+				return left.calculateResult(extraFactor*right.total, data, invFactors)
+					+ right.calculateResult(extraFactor*left.total, data, invFactors);
+			}
+		};
+		template<typename Sample, int n, int index>
+		struct ProductRange<Sample, n, index, index> {
+			using Array = std::array<Sample, (n + 1)>;
+
+			const Sample total;
+			ProductRange(Sample x) : total(x - index) {}
+
+			template<class Data>
+			Sample calculateResult(Sample extraFactor, const Data &data, const Array &invFactors) {
+				return extraFactor*data[index]*invFactors[index];
+			}
+		};
+	}
+	/** Fixed-order Lagrange interpolation.
+	\diagram{interpolator-LagrangeN.svg,aliasing and amplitude/delay errors for different sizes}
+	*/
+	template<typename Sample, int n>
+	struct InterpolatorLagrangeN {
+		static constexpr int inputLength = n + 1;
+		static constexpr int latency = (n - 1)/2;
+
+		using Array = std::array<Sample, (n + 1)>;
+		Array invDivisors;
+
+		InterpolatorLagrangeN() {
+			for (int j = 0; j <= n; ++j) {
+				double divisor = 1;
+				for (int k = 0; k < j; ++k) divisor *= (j - k);
+				for (int k = j + 1; k <= n; ++k) divisor *= (j - k);
+				invDivisors[j] = 1/divisor;
+			}
+		}
+
+		template<class Data>
+		Sample fractional(const Data &data, Sample fractional) const {
+			constexpr int mid = n/2;
+			using Left = _franck_impl::ProductRange<Sample, n, 0, mid>;
+			using Right = _franck_impl::ProductRange<Sample, n, mid + 1, n>;
+
+			Sample x = fractional + latency;
+
+			Left left(x);
+			Right right(x);
+
+			return left.calculateResult(right.total, data, invDivisors) + right.calculateResult(left.total, data, invDivisors);
+		}
+	};
+	template<typename Sample>
+	using InterpolatorLagrange3 = InterpolatorLagrangeN<Sample, 3>;
+	template<typename Sample>
+	using InterpolatorLagrange7 = InterpolatorLagrangeN<Sample, 7>;
+	template<typename Sample>
+	using InterpolatorLagrange19 = InterpolatorLagrangeN<Sample, 19>;
+
+	/** Fixed-size Kaiser-windowed sinc interpolation.
+	\diagram{interpolator-KaiserSincN.svg,aliasing and amplitude/delay errors for different sizes}
+	If `minimumPhase` is enabled, a minimum-phase version of the kernel is used:
+	\diagram{interpolator-KaiserSincN-min.svg,aliasing and amplitude/delay errors for minimum-phase mode}
+	*/
+	template<typename Sample, int n, bool minimumPhase=false>
+	struct InterpolatorKaiserSincN {
+		static constexpr int inputLength = n;
+		static constexpr Sample latency = minimumPhase ? 0 : (n*Sample(0.5) - 1);
+
+		int subSampleSteps;
+		std::vector<Sample> coefficients;
+		
+		InterpolatorKaiserSincN() : InterpolatorKaiserSincN(0.5 - 0.45/std::sqrt(n)) {}
+		InterpolatorKaiserSincN(double passFreq) : InterpolatorKaiserSincN(passFreq, 1 - passFreq) {}
+		InterpolatorKaiserSincN(double passFreq, double stopFreq) {
+			subSampleSteps = 2*n; // Heuristic again.  Really it depends on the bandwidth as well.
+			double kaiserBandwidth = (stopFreq - passFreq)*(n + 1.0/subSampleSteps);
+			kaiserBandwidth += 1.25/kaiserBandwidth; // We want to place the first zero, but (because using this to window a sinc essentially integrates it in the freq-domain), our ripples (and therefore zeroes) are out of phase.  This is a heuristic fix.
+			double sincScale = M_PI*(passFreq + stopFreq);
+
+			double centreIndex = n*subSampleSteps*0.5, scaleFactor = 1.0/subSampleSteps;
+			std::vector<Sample> windowedSinc(subSampleSteps*n + 1);
+			
+			::signalsmith::windows::Kaiser::withBandwidth(kaiserBandwidth, false).fill(windowedSinc, windowedSinc.size());
+
+			for (size_t i = 0; i < windowedSinc.size(); ++i) {
+				double x = (i - centreIndex)*scaleFactor;
+				int intX = std::round(x);
+				if (intX != 0 && std::abs(x - intX) < 1e-6) {
+					// Exact 0s
+					windowedSinc[i] = 0;
+				} else if (std::abs(x) > 1e-6) {
+					double p = x*sincScale;
+					windowedSinc[i] *= std::sin(p)/p;
+				}
+			}
+			
+			if (minimumPhase) {
+				signalsmith::fft::FFT<Sample> fft(windowedSinc.size()*2, 1);
+				windowedSinc.resize(fft.size(), 0);
+				std::vector<std::complex<Sample>> spectrum(fft.size());
+				std::vector<std::complex<Sample>> cepstrum(fft.size());
+				fft.fft(windowedSinc, spectrum);
+				for (size_t i = 0; i < fft.size(); ++i) {
+					spectrum[i] = std::log(std::abs(spectrum[i]) + 1e-30);
+				}
+				fft.fft(spectrum, cepstrum);
+				for (size_t i = 1; i < fft.size()/2; ++i) {
+					cepstrum[i] *= 0;
+				}
+				for (size_t i = fft.size()/2 + 1; i < fft.size(); ++i) {
+					cepstrum[i] *= 2;
+				}
+				Sample scaling = Sample(1)/fft.size();
+				fft.ifft(cepstrum, spectrum);
+
+				for (size_t i = 0; i < fft.size(); ++i) {
+					Sample phase = spectrum[i].imag()*scaling;
+					Sample mag = std::exp(spectrum[i].real()*scaling);
+					spectrum[i] = {mag*std::cos(phase), mag*std::sin(phase)};
+				}
+				fft.ifft(spectrum, cepstrum);
+				windowedSinc.resize(subSampleSteps*n + 1);
+				windowedSinc.shrink_to_fit();
+				for (size_t i = 0; i < windowedSinc.size(); ++i) {
+					windowedSinc[i] = cepstrum[i].real()*scaling;
+				}
+			}
+			
+			// Re-order into FIR fractional-delay blocks
+			coefficients.resize(n*(subSampleSteps + 1));
+			for (int k = 0; k <= subSampleSteps; ++k) {
+				for (int i = 0; i < n; ++i) {
+					coefficients[k*n + i] = windowedSinc[(subSampleSteps - k) + i*subSampleSteps];
+				}
+			}
+		}
+		
+		template<class Data>
+		Sample fractional(const Data &data, Sample fractional) const {
+			Sample subSampleDelay = fractional*subSampleSteps;
+			int lowIndex = subSampleDelay;
+			if (lowIndex >= subSampleSteps) lowIndex = subSampleSteps - 1;
+			Sample subSampleFractional = subSampleDelay - lowIndex;
+			int highIndex = lowIndex + 1;
+			
+			Sample sumLow = 0, sumHigh = 0;
+			const Sample *coeffLow = coefficients.data() + lowIndex*n;
+			const Sample *coeffHigh = coefficients.data() + highIndex*n;
+			for (int i = 0; i < n; ++i) {
+				sumLow += data[i]*coeffLow[i];
+				sumHigh += data[i]*coeffHigh[i];
+			}
+			return sumLow + (sumHigh - sumLow)*subSampleFractional;
+		}
+	};
+
+	template<typename Sample>
+	using InterpolatorKaiserSinc20 = InterpolatorKaiserSincN<Sample, 20>;
+	template<typename Sample>
+	using InterpolatorKaiserSinc8 = InterpolatorKaiserSincN<Sample, 8>;
+	template<typename Sample>
+	using InterpolatorKaiserSinc4 = InterpolatorKaiserSincN<Sample, 4>;
+
+	template<typename Sample>
+	using InterpolatorKaiserSinc20Min = InterpolatorKaiserSincN<Sample, 20, true>;
+	template<typename Sample>
+	using InterpolatorKaiserSinc8Min = InterpolatorKaiserSincN<Sample, 8, true>;
+	template<typename Sample>
+	using InterpolatorKaiserSinc4Min = InterpolatorKaiserSincN<Sample, 4, true>;
+	///  @}
+	
+	/** @brief A delay-line reader which uses an external buffer
+ 
+		This is useful if you have multiple delay-lines reading from the same buffer.
+	*/
+	template<class Sample, template<typename> class Interpolator=InterpolatorLinear>
+	class Reader : public Interpolator<Sample> /* so we can get the empty-base-class optimisation */ {
+		using Super = Interpolator<Sample>;
+	public:
+		Reader () {}
+		/// Pass in a configured interpolator
+		Reader (const Interpolator<Sample> &interpolator) : Super(interpolator) {}
+	
+		template<typename Buffer>
+		Sample read(const Buffer &buffer, Sample delaySamples) const {
+			int startIndex = delaySamples;
+			Sample remainder = delaySamples - startIndex;
+			
+			// Delay buffers use negative indices, but interpolators use positive ones
+			using View = decltype(buffer - startIndex);
+			struct Flipped {
+				 View view;
+				 Sample operator [](int i) const {
+					return view[-i];
+				 }
+			};
+			return Super::fractional(Flipped{buffer - startIndex}, remainder);
+		}
+	};
+
+	/**	@brief A single-channel delay-line containing its own buffer.*/
+	template<class Sample, template<typename> class Interpolator=InterpolatorLinear>
+	class Delay : private Reader<Sample, Interpolator> {
+		using Super = Reader<Sample, Interpolator>;
+		Buffer<Sample> buffer;
+	public:
+		static constexpr Sample latency = Super::latency;
+
+		Delay(int capacity=0) : buffer(1 + capacity + Super::inputLength) {}
+		/// Pass in a configured interpolator
+		Delay(const Interpolator<Sample> &interp, int capacity=0) : Super(interp), buffer(1 + capacity + Super::inputLength) {}
+		
+		void reset(Sample value=Sample()) {
+			buffer.reset(value);
+		}
+		void resize(int minCapacity, Sample value=Sample()) {
+			buffer.resize(minCapacity + Super::inputLength, value);
+		}
+		
+		/** Read a sample from `delaySamples` >= 0 in the past.
+		The interpolator may add its own latency on top of this (see `Delay::latency`).  The default interpolation (linear) has 0 latency.
+		*/
+		Sample read(Sample delaySamples) const {
+			return Super::read(buffer, delaySamples);
+		}
+		/// Writes a sample. Returns the same object, so that you can say `delay.write(v).read(delay)`.
+		Delay & write(Sample value) {
+			++buffer;
+			buffer[0] = value;
+			return *this;
+		}
+	};
+
+	/**	@brief A multi-channel delay-line with its own buffer. */
+	template<class Sample, template<typename> class Interpolator=InterpolatorLinear>
+	class MultiDelay : private Reader<Sample, Interpolator> {
+		using Super = Reader<Sample, Interpolator>;
+		int channels;
+		MultiBuffer<Sample> multiBuffer;
+	public:
+		static constexpr Sample latency = Super::latency;
+
+		MultiDelay(int channels=0, int capacity=0) : channels(channels), multiBuffer(channels, 1 + capacity + Super::inputLength) {}
+
+		void reset(Sample value=Sample()) {
+			multiBuffer.reset(value);
+		}
+		void resize(int nChannels, int capacity, Sample value=Sample()) {
+			channels = nChannels;
+			multiBuffer.resize(channels, capacity + Super::inputLength, value);
+		}
+		
+		/// A single-channel delay-line view, similar to a `const Delay`
+		struct ChannelView {
+			static constexpr Sample latency = Super::latency;
+
+			const Super &reader;
+			typename MultiBuffer<Sample>::ConstChannel channel;
+			
+			Sample read(Sample delaySamples) const {
+				return reader.read(channel, delaySamples);
+			}
+		};
+		ChannelView operator [](int channel) const {
+			return ChannelView{*this, multiBuffer[channel]};
+		}
+
+		/// A multi-channel result, lazily calculating samples
+		struct DelayView {
+			Super &reader;
+			typename MultiBuffer<Sample>::ConstView view;
+			Sample delaySamples;
+			
+			// Calculate samples on-the-fly
+			Sample operator [](int c) const {
+				return reader.read(view[c], delaySamples);
+			}
+		};
+		DelayView read(Sample delaySamples) {
+			return DelayView{*this, multiBuffer.constView(), delaySamples};
+		}
+		/// Reads into the provided output structure
+		template<class Output>
+		void read(Sample delaySamples, Output &output) {
+			for (int c = 0; c < channels; ++c) {
+				output[c] = Super::read(multiBuffer[c], delaySamples);
+			}
+		}
+		/// Reads separate delays for each channel
+		template<class Delays, class Output>
+		void readMulti(const Delays &delays, Output &output) {
+			for (int c = 0; c < channels; ++c) {
+				output[c] = Super::read(multiBuffer[c], delays[c]);
+			}
+		}
+		template<class Data>
+		MultiDelay & write(const Data &data) {
+			++multiBuffer;
+			for (int c = 0; c < channels; ++c) {
+				multiBuffer[c][0] = data[c];
+			}
+			return *this;
+		}
+	};
+
+/** @} */
+}} // signalsmith::delay::
+#endif // include guard

--- a/examples/dsp/envelopes.h
+++ b/examples/dsp/envelopes.h
@@ -1,0 +1,523 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_ENVELOPES_H
+#define SIGNALSMITH_DSP_ENVELOPES_H
+
+#include <cmath>
+#include <random>
+#include <vector>
+#include <iterator>
+
+namespace signalsmith {
+namespace envelopes {
+	/**	@defgroup Envelopes Envelopes and LFOs
+		@brief LFOs, envelopes and filters for manipulating them
+		
+		@{
+		@file
+	*/
+	
+	/**	An LFO based on cubic segments.
+		You can randomise the rate and/or the depth.  Randomising the depth past `0.5` means it no longer neatly alternates sides:
+			\diagram{cubic-lfo-example.svg,Some example LFO curves.}
+		Without randomisation, it is approximately sine-like:
+			\diagram{cubic-lfo-spectrum-pure.svg}
+	*/
+	class CubicLfo {
+		float ratio = 0;
+		float ratioStep = 0;
+		
+		float valueFrom = 0, valueTo = 1, valueRange = 1;
+		float targetLow = 0, targetHigh = 1;
+		float targetRate = 0;
+		float rateRandom = 0.5, depthRandom = 0;
+		bool freshReset = true;
+		
+		std::default_random_engine randomEngine;
+		std::uniform_real_distribution<float> randomUnit;
+		float random() {
+			return randomUnit(randomEngine);
+		}
+		float randomRate() {
+			return targetRate*exp(rateRandom*(random() - 0.5));
+		}
+		float randomTarget(float previous) {
+			float randomOffset = depthRandom*random()*(targetLow - targetHigh);
+			if (previous < (targetLow + targetHigh)*0.5f) {
+				return targetHigh + randomOffset;
+			} else {
+				return targetLow - randomOffset;
+			}
+		}
+	public:
+		CubicLfo() : randomEngine(std::random_device()()), randomUnit(0, 1) {
+			reset();
+		}
+		CubicLfo(long seed) : randomUnit(0, 1) {
+			randomEngine.seed(seed);
+			reset();
+		}
+
+		/// Resets the LFO state, starting with random phase.
+		void reset() {
+			ratio = random();
+			ratioStep = randomRate();
+			if (random() < 0.5) {
+				valueFrom = targetLow;
+				valueTo = targetHigh;
+			} else {
+				valueFrom = targetHigh;
+				valueTo = targetLow;
+			}
+			valueRange = valueTo - valueFrom;
+			freshReset = true;
+		}
+		/** Smoothly updates the LFO parameters.
+
+		If called directly after `.reset()`, oscillation will immediately start within the specified range.  Otherwise, it will remain smooth and fit within the new range after at most one cycle:
+			\diagram{cubic-lfo-changes.svg}
+
+		The LFO will complete a full oscillation in (approximately) `1/rate` samples.  `rateVariation` can be any number, but 0-1 is a good range.
+		
+		`depthVariation` must be in the range [0, 1], where ≤ 0.5 produces random amplitude but still alternates up/down.
+			\diagram{cubic-lfo-spectrum.svg,Spectra for the two types of randomisation - note the jump as depth variation goes past 50%}
+		*/
+		void set(float low, float high, float rate, float rateVariation=0, float depthVariation=0) {
+			rate *= 2; // We want to go up and down during this period
+			targetRate = rate;
+			targetLow = std::min(low, high);
+			targetHigh = std::max(low, high);
+			rateRandom = rateVariation;
+			depthRandom = std::min<float>(1, std::max<float>(0, depthVariation));
+			
+			// If we haven't called .next() yet, don't bother being smooth.
+			if (freshReset) return reset();
+
+			// Only update the current rate if it's outside our new random-variation range
+			float maxRandomRatio = exp((float)0.5*rateRandom);
+			if (ratioStep > rate*maxRandomRatio || ratioStep < rate/maxRandomRatio) {
+				ratioStep = randomRate();
+			}
+		}
+		
+		/// Returns the next output sample
+		float next() {
+			freshReset = false;
+			float result = ratio*ratio*(3 - 2*ratio)*valueRange + valueFrom;
+
+			ratio += ratioStep;
+			while (ratio >= 1) {
+				ratio -= 1;
+				ratioStep = randomRate();
+				valueFrom = valueTo;
+				valueTo = randomTarget(valueFrom);
+				valueRange = valueTo - valueFrom;
+			}
+			return result;
+		}
+	};
+	
+	/** Variable-width rectangular sum */
+	template<typename Sample=double>
+	class BoxSum {
+		int bufferLength, index;
+		std::vector<Sample> buffer;
+		Sample sum = 0, wrapJump = 0;
+	public:
+		BoxSum(int maxLength) {
+			resize(maxLength);
+		}
+
+		/// Sets the maximum size (and reset contents)
+		void resize(int maxLength) {
+			bufferLength = maxLength + 1;
+			buffer.resize(bufferLength);
+			if (maxLength != 0) buffer.shrink_to_fit();
+			reset();
+		}
+		
+		/// Resets (with an optional "fill" value)
+		void reset(Sample value=Sample()) {
+			index = 0;
+			sum = 0;
+			for (size_t i = 0; i < buffer.size(); ++i) {
+				buffer[i] = sum;
+				sum += value;
+			}
+			wrapJump = sum;
+			sum = 0;
+		}
+		
+		Sample read(int width) {
+			int readIndex = index - width;
+			double result = sum;
+			if (readIndex < 0) {
+				result += wrapJump;
+				readIndex += bufferLength;
+			}
+			return result - buffer[readIndex];
+		}
+		
+		void write(Sample value) {
+			++index;
+			if (index == bufferLength) {
+				index = 0;
+				wrapJump = sum;
+				sum = 0;
+			}
+			sum += value;
+			buffer[index] = sum;
+		}
+
+		Sample readWrite(Sample value, int width) {
+			write(value);
+			return read(width);
+		}
+	};
+	
+	/** Rectangular moving average filter (FIR).
+		\diagram{box-filter-example.svg}
+		A filter of length 1 has order 0 (i.e. does nothing). */
+	template<typename Sample=double>
+	class BoxFilter {
+		BoxSum<Sample> boxSum;
+		int _length, _maxLength;
+		Sample multiplier;
+	public:
+		BoxFilter(int maxLength) : boxSum(maxLength) {
+			resize(maxLength);
+		}
+		/// Sets the maximum size (and current size, and resets)
+		void resize(int maxLength) {
+			_maxLength = maxLength;
+			boxSum.resize(maxLength);
+			set(maxLength);
+		}
+		/// Sets the current size (expanding/allocating only if needed)
+		void set(int length) {
+			_length = length;
+			multiplier = Sample(1)/length;
+			if (length > _maxLength) resize(length);
+		}
+		
+		/// Resets (with an optional "fill" value)
+		void reset(Sample fill=Sample()) {
+			boxSum.reset(fill);
+		}
+		
+		Sample operator()(Sample v) {
+			return boxSum.readWrite(v, _length)*multiplier;
+		}
+	};
+
+	/** FIR filter made from a stack of `BoxFilter`s.
+		This filter has a non-negative impulse (monotonic step response), making it useful for smoothing positive-only values.  It provides an optimal set of box-lengths, chosen to minimise peaks in the stop-band:
+			\diagram{box-stack-long.svg,Impulse responses for various stack sizes at length N=1000}
+		Since the underlying box-averages must have integer width, the peaks are slightly higher for shorter lengths with higher numbers of layers:
+			\diagram{box-stack-short-freq.svg,Frequency responses for various stack sizes at length N=30}
+	*/
+	template<typename Sample=double>
+	class BoxStackFilter {
+		struct Layer {
+			double ratio = 0, lengthError = 0;
+			int length = 0;
+			BoxFilter<Sample> filter{0};
+			Layer() {}
+		};
+		int _size;
+		std::vector<Layer> layers;
+
+		template<class Iterable>
+		void setupLayers(const Iterable &ratios) {
+			layers.resize(0);
+			double sum = 0;
+			for (auto ratio : ratios) {
+				Layer layer;
+				layer.ratio = ratio;
+				layers.push_back(layer);
+				sum += ratio;
+			}
+			double factor = 1/sum;
+			for (auto &l : layers) {
+				l.ratio *= factor;
+			}
+		}
+	public:
+		BoxStackFilter(int maxSize, int layers=4) {
+			resize(maxSize, layers);
+		}
+
+		/// Returns an optimal set of length ratios (heuristic for larger depths)
+		static std::vector<double> optimalRatios(int layerCount) {
+			// Coefficients up to 6, found through numerical search
+			static double hardcoded[] = {1, 0.58224186169, 0.41775813831, 0.404078562416, 0.334851475794, 0.261069961789, 0.307944914938, 0.27369945234, 0.22913263601, 0.189222996712, 0.248329349789, 0.229253789144, 0.201191468123, 0.173033035122, 0.148192357821, 0.205275202874, 0.198413552119, 0.178256637764, 0.157821404506, 0.138663023387, 0.121570179349 /*, 0.178479592135, 0.171760666359, 0.158434068954, 0.143107825806, 0.125907148711, 0.11853946895, 0.103771229086, 0.155427880834, 0.153063152848, 0.142803459422, 0.131358358458, 0.104157805178, 0.119338029601, 0.0901675284678, 0.103683785192, 0.143949349747, 0.139813248378, 0.132051305252, 0.122216776152, 0.112888320989, 0.102534988632, 0.0928386714364, 0.0719750997699, 0.0817322396428, 0.130587011572, 0.127244563184, 0.121228748787, 0.113509941974, 0.105000272288, 0.0961938290157, 0.0880639725438, 0.0738389766046, 0.0746781936619, 0.0696544903682 */};
+			if (layerCount <= 0) {
+				return {};
+			} else if (layerCount <= 6) {
+				double *start = &hardcoded[layerCount*(layerCount - 1)/2];
+				return std::vector<double>(start, start + layerCount);
+			}
+			std::vector<double> result(layerCount);
+
+			double invN = 1.0/layerCount, sqrtN = std::sqrt(layerCount);
+			double p = 1 - invN;
+			double k = 1 + 4.5/sqrtN + 0.08*sqrtN;
+
+			double sum = 0;
+			for (int i = 0; i < layerCount; ++i) {
+				double x = i*invN;
+				double power = -x*(1 - p*std::exp(-x*k));
+				double length = std::pow(2, power);
+				result[i] = length;
+				sum += length;
+			}
+			double factor = 1/sum;
+			for (auto &r : result) r *= factor;
+			return result;
+		}
+		/** Approximate (optimal) bandwidth for a given number of layers
+		\diagram{box-stack-bandwidth.svg,Approximate main lobe width (bandwidth)}
+		*/
+		static constexpr double layersToBandwidth(int layers) {
+			return 1.58*(layers + 0.1);
+		}
+		/** Approximate (optimal) peak in the stop-band
+		\diagram{box-stack-peak.svg,Heuristic stop-band peak}
+		*/
+		static constexpr double layersToPeakDb(int layers) {
+			return 5 - layers*18;
+		}
+		
+		/// Sets size using an optimal (heuristic at larger sizes) set of length ratios
+		void resize(int maxSize, int layerCount) {
+			resize(maxSize, optimalRatios(layerCount));
+		}
+		/// Sets the maximum (and current) impulse response length and explicit length ratios
+		template<class List>
+		auto resize(int maxSize, List ratios) -> decltype(void(std::begin(ratios)), void(std::end(ratios))) {
+			setupLayers(ratios);
+			for (auto &layer : layers) layer.filter.resize(0); // .set() will expand it later
+			_size = -1;
+			set(maxSize);
+			reset();
+		}
+		void resize(int maxSize, std::initializer_list<double> ratios) {
+			resize<const std::initializer_list<double> &>(maxSize, ratios);
+		}
+		
+		/// Sets the impulse response length (does not reset if `size` ≤ `maxSize`)
+		void set(int size) {
+			if (layers.size() == 0) return; // meaningless
+
+			if (_size == size) return;
+			_size = size;
+			int order = size - 1;
+			int totalOrder  = 0;
+			
+			for (auto &layer : layers) {
+				double layerOrderFractional = layer.ratio*order;
+				int layerOrder = int(layerOrderFractional);
+				layer.length = layerOrder + 1;
+				layer.lengthError = layerOrder - layerOrderFractional;
+				totalOrder += layerOrder;
+			}
+			// Round some of them up, so the total is correct - this is O(N²), but `layers.size()` is small
+			while (totalOrder < order) {
+				int minIndex = 0;
+				double minError = layers[0].lengthError;
+				for (size_t i = 1; i < layers.size(); ++i) {
+					if (layers[i].lengthError < minError) {
+						minError = layers[i].lengthError;
+						minIndex = i;
+					}
+				}
+				layers[minIndex].length++;
+				layers[minIndex].lengthError += 1;
+				totalOrder++;
+			}
+			for (auto &layer : layers) layer.filter.set(layer.length);
+		}
+
+		/// Resets the filter
+		void reset(Sample fill=Sample()) {
+			for (auto &layer : layers) layer.filter.reset(fill);
+		}
+		
+		Sample operator()(Sample v) {
+			for (auto &layer : layers) {
+				v = layer.filter(v);
+			}
+			return v;
+		}
+	};
+	
+	/** Peak-hold filter.
+		\diagram{peak-hold.svg}
+		
+		The size is variable, and can be changed instantly with `.set()`, or by using `.push()`/`.pop()` in an unbalanced way.
+
+		This has complexity O(1) every sample when the length remains constant (balanced `.push()`/`.pop()`, or using `filter(v)`), and amortised O(1) complexity otherwise.  To avoid allocations while running, it pre-allocates a vector (not a `std::deque`) which determines the maximum length.
+	*/
+	template<typename Sample>
+	class PeakHold {
+		static constexpr Sample lowest = std::numeric_limits<Sample>::lowest();
+		int bufferMask;
+		std::vector<Sample> buffer;
+		int backIndex = 0, middleStart = 0, workingIndex = 0, middleEnd = 0, frontIndex = 0;
+		Sample frontMax = lowest, workingMax = lowest, middleMax = lowest;
+		
+	public:
+		PeakHold(int maxLength) {
+			resize(maxLength);
+		}
+		int size() {
+			return frontIndex - backIndex;
+		}
+		void resize(int maxLength) {
+			int bufferLength = 1;
+			while (bufferLength < maxLength) bufferLength *= 2;
+			buffer.resize(bufferLength);
+			bufferMask = bufferLength - 1;
+			
+			frontIndex = backIndex + maxLength;
+			reset();
+		}
+		void reset(Sample fill=lowest) {
+			int prevSize = size();
+			buffer.assign(buffer.size(), fill);
+			frontMax = workingMax = middleMax = lowest;
+			middleEnd = workingIndex = frontIndex = 0;
+			middleStart = middleEnd - (prevSize/2);
+			backIndex = frontIndex - prevSize;
+		}
+		/** Sets the size immediately.
+		Must be `0 <= newSize <= maxLength` (see constructor and `.resize()`).
+		
+		Shrinking doesn't destroy information, and if you expand again (with `preserveCurrentPeak=false`), you will get the same output as before shrinking.  Expanding when `preserveCurrentPeak` is enabled is destructive, re-writing its history such that the current output value is unchanged.*/
+		void set(int newSize, bool preserveCurrentPeak=false) {
+			while (size() < newSize) {
+				Sample &backPrev = buffer[backIndex&bufferMask];
+				--backIndex;
+				Sample &back = buffer[backIndex&bufferMask];
+				back = preserveCurrentPeak ? backPrev : std::max(back, backPrev);
+			}
+			while (size() > newSize) {
+				pop();
+			}
+		}
+		
+		void push(Sample v) {
+			buffer[frontIndex&bufferMask] = v;
+			++frontIndex;
+			frontMax = std::max(frontMax, v);
+		}
+		void pop() {
+			if (backIndex == middleStart) {
+				// Move along the maximums
+				workingMax = lowest;
+				middleMax = frontMax;
+				frontMax = lowest;
+
+				int prevFrontLength = frontIndex - middleEnd;
+				int prevMiddleLength = middleEnd - middleStart;
+				if (prevFrontLength <= prevMiddleLength + 1) {
+					// Swap over simply
+					middleStart = middleEnd;
+					middleEnd = frontIndex;
+					workingIndex = middleEnd;
+				} else {
+					// The front is longer than the middle - only happens if unbalanced
+					// We don't move *all* of the front over, keeping half the surplus in the front
+					int middleLength = (frontIndex - middleStart)/2;
+					middleStart = middleEnd;
+					middleEnd += middleLength;
+
+					// Working index is close enough that it will be finished by the time the back is empty
+					int backLength = middleStart - backIndex;
+					int workingLength = std::min(backLength, middleEnd - middleStart);
+					workingIndex = middleStart + workingLength;
+
+					// Since the front was not completely consumed, we re-calculate the front's maximum
+					for (int i = middleEnd; i != frontIndex; ++i) {
+						frontMax = std::max(frontMax, buffer[i&bufferMask]);
+					}
+					// The index might not start at the end of the working block - compute the last bit immediately
+					for (int i = middleEnd - 1; i != workingIndex - 1; --i) {
+						buffer[i&bufferMask] = workingMax = std::max(workingMax, buffer[i&bufferMask]);
+					}
+				}
+
+				// Is the new back (previous middle) empty? Only happens if unbalanced
+				if (backIndex == middleStart) {
+					 // swap over again (front's empty, no change)
+					workingMax = lowest;
+					middleMax = frontMax;
+					frontMax = lowest;
+					middleStart = workingIndex = middleEnd;
+	
+					if (backIndex == middleStart) {
+						--backIndex; // Only happens if you pop from an empty list - fail nicely
+					}
+				}
+				
+				buffer[frontIndex&bufferMask] = lowest; // In case of length 0, when everything points at this value
+			}
+
+			++backIndex;
+			if (workingIndex != middleStart) {
+				--workingIndex;
+				buffer[workingIndex&bufferMask] = workingMax = std::max(workingMax, buffer[workingIndex&bufferMask]);
+			}
+		}
+		Sample read() {
+			Sample backMax = buffer[backIndex&bufferMask];
+			return std::max(backMax, std::max(middleMax, frontMax));
+		}
+		
+		// For simple use as a constant-length filter
+		Sample operator ()(Sample v) {
+			push(v);
+			pop();
+			return read();
+		}
+	};
+	
+	/** Peak-decay filter with a linear shape and fixed-time return to constant value.
+		\diagram{peak-decay-linear.svg}
+		This is equivalent to a `BoxFilter` which resets itself whenever the output would be less than the input.
+	*/
+	template<typename Sample=double>
+	class PeakDecayLinear {
+		static constexpr Sample lowest = std::numeric_limits<Sample>::lowest();
+		PeakHold<Sample> peakHold;
+		Sample value = lowest;
+		Sample stepMultiplier = 1;
+	public:
+		PeakDecayLinear(int maxLength) : peakHold(maxLength) {
+			set(maxLength);
+		}
+		void resize(int maxLength) {
+			peakHold.resize(maxLength);
+			reset();
+		}
+		void set(double length) {
+			peakHold.set(std::ceil(length));
+			// Overshoot slightly but don't exceed 1
+			stepMultiplier = Sample(1.0001)/std::max(1.0001, length);
+		}
+		void reset(Sample start=lowest) {
+			peakHold.reset(start);
+			set(peakHold.size());
+			value = start;
+		}
+		
+		Sample operator ()(Sample v) {
+			Sample peak = peakHold.read();
+			peakHold(v);
+			return value = std::max<Sample>(v, value + (v - peak)*stepMultiplier);
+		}
+	};
+
+/** @} */
+}} // signalsmith::envelopes::
+#endif // include guard

--- a/examples/dsp/fft.h
+++ b/examples/dsp/fft.h
@@ -1,0 +1,521 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_FFT_V5
+#define SIGNALSMITH_FFT_V5
+
+#include "./perf.h"
+
+#include <vector>
+#include <complex>
+#include <cmath>
+
+namespace signalsmith { namespace fft {
+	/**	@defgroup FFT FFT (complex and real)
+		@brief Fourier transforms (complex and real)
+
+		@{
+		@file
+	*/
+
+	namespace _fft_impl {
+
+		template <typename V>
+		SIGNALSMITH_INLINE V complexReal(const std::complex<V> &c) {
+			return ((V*)(&c))[0];
+		}
+		template <typename V>
+		SIGNALSMITH_INLINE V complexImag(const std::complex<V> &c) {
+			return ((V*)(&c))[1];
+		}
+
+		// Complex multiplication has edge-cases around Inf/NaN - handling those properly makes std::complex non-inlineable, so we use our own
+		template <bool conjugateSecond, typename V>
+		SIGNALSMITH_INLINE std::complex<V> complexMul(const std::complex<V> &a, const std::complex<V> &b) {
+			V aReal = complexReal(a), aImag = complexImag(a);
+			V bReal = complexReal(b), bImag = complexImag(b);
+			return conjugateSecond ? std::complex<V>{
+				bReal*aReal + bImag*aImag,
+				bReal*aImag - bImag*aReal
+			} : std::complex<V>{
+				aReal*bReal - aImag*bImag,
+				aReal*bImag + aImag*bReal
+			};
+		}
+
+		template<bool flipped, typename V>
+		SIGNALSMITH_INLINE std::complex<V> complexAddI(const std::complex<V> &a, const std::complex<V> &b) {
+			V aReal = complexReal(a), aImag = complexImag(a);
+			V bReal = complexReal(b), bImag = complexImag(b);
+			return flipped ? std::complex<V>{
+				aReal + bImag,
+				aImag - bReal
+			} : std::complex<V>{
+				aReal - bImag,
+				aImag + bReal
+			};
+		}
+
+		// Use SFINAE to get an iterator from std::begin(), if supported - otherwise assume the value itself is an iterator
+		template<typename T, typename=void>
+		struct GetIterator {
+			static T get(const T &t) {
+				return t;
+			}
+		};
+		template<typename T>
+		struct GetIterator<T, decltype((void)std::begin(std::declval<T>()))> {
+			static auto get(const T &t) -> decltype(std::begin(t)) {
+				return std::begin(t);
+			}
+		};
+	}
+
+	/** Floating-point FFT implementation.
+	It is fast for 2^a * 3^b.
+	Here are the peak and RMS errors for `float`/`double` computation:
+	\diagram{fft-errors.svg Simulated errors for pure-tone harmonic inputs\, compared to a theoretical upper bound from "Roundoff error analysis of the fast Fourier transform" (G. Ramos, 1971)}
+	*/
+	template<typename V=double>
+	class FFT {
+		using complex = std::complex<V>;
+		size_t _size;
+		std::vector<complex> workingVector;
+		
+		enum class StepType {
+			generic, step2, step3, step4
+		};
+		struct Step {
+			StepType type;
+			size_t factor;
+			size_t startIndex;
+			size_t innerRepeats;
+			size_t outerRepeats;
+			size_t twiddleIndex;
+		};
+		std::vector<size_t> factors;
+		std::vector<Step> plan;
+		std::vector<complex> twiddleVector;
+		
+		struct PermutationPair {size_t from, to;};
+		std::vector<PermutationPair> permutation;
+		
+		void addPlanSteps(size_t factorIndex, size_t start, size_t length, size_t repeats) {
+			if (factorIndex >= factors.size()) return;
+			
+			size_t factor = factors[factorIndex];
+			if (factorIndex + 1 < factors.size()) {
+				if (factors[factorIndex] == 2 && factors[factorIndex + 1] == 2) {
+					++factorIndex;
+					factor = 4;
+				}
+			}
+
+			size_t subLength = length/factor;
+			Step mainStep{StepType::generic, factor, start, subLength, repeats, twiddleVector.size()};
+
+			if (factor == 2) mainStep.type = StepType::step2;
+			if (factor == 3) mainStep.type = StepType::step3;
+			if (factor == 4) mainStep.type = StepType::step4;
+
+			// Twiddles
+			bool foundStep = false;
+			for (const Step &existingStep : plan) {
+				if (existingStep.factor == mainStep.factor && existingStep.innerRepeats == mainStep.innerRepeats) {
+					foundStep = true;
+					mainStep.twiddleIndex = existingStep.twiddleIndex;
+					break;
+				}
+			}
+			if (!foundStep) {
+				for (size_t i = 0; i < subLength; ++i) {
+					for (size_t f = 0; f < factor; ++f) {
+						double phase = 2*M_PI*i*f/length;
+						complex twiddle = {V(std::cos(phase)), V(-std::sin(phase))};
+						twiddleVector.push_back(twiddle);
+					}
+				}
+			}
+
+			if (repeats == 1 && sizeof(complex)*subLength > 65536) {
+				for (size_t i = 0; i < factor; ++i) {
+					addPlanSteps(factorIndex + 1, start + i*subLength, subLength, 1);
+				}
+			} else {
+				addPlanSteps(factorIndex + 1, start, subLength, repeats*factor);
+			}
+			plan.push_back(mainStep);
+		}
+		void setPlan() {
+			factors.resize(0);
+			size_t size = _size, factor = 2;
+			while (size > 1) {
+				if (size%factor == 0) {
+					factors.push_back(factor);
+					size /= factor;
+				} else if (factor > sqrt(size)) {
+					factor = size;
+				} else {
+					++factor;
+				}
+			}
+
+			plan.resize(0);
+			twiddleVector.resize(0);
+			addPlanSteps(0, 0, _size, 1);
+			
+			permutation.resize(0);
+			permutation.push_back(PermutationPair{0, 0});
+			size_t indexLow = 0, indexHigh = factors.size();
+			size_t inputStepLow = _size, outputStepLow = 1;
+			size_t inputStepHigh = 1, outputStepHigh = _size;
+			while (outputStepLow*inputStepHigh < _size) {
+				size_t f, inputStep, outputStep;
+				if (outputStepLow <= inputStepHigh) {
+					f = factors[indexLow++];
+					inputStep = (inputStepLow /= f);
+					outputStep = outputStepLow;
+					outputStepLow *= f;
+				} else {
+					f = factors[--indexHigh];
+					inputStep = inputStepHigh;
+					inputStepHigh *= f;
+					outputStep = (outputStepHigh /= f);
+				}
+				size_t oldSize = permutation.size();
+				for (size_t i = 1; i < f; ++i) {
+					for (size_t j = 0; j < oldSize; ++j) {
+						PermutationPair pair = permutation[j];
+						pair.from += i*inputStep;
+						pair.to += i*outputStep;
+						permutation.push_back(pair);
+					}
+				}
+			}
+		}
+
+		template<bool inverse, typename RandomAccessIterator>
+		void fftStepGeneric(RandomAccessIterator &&origData, const Step &step) {
+			complex *working = workingVector.data();
+			const size_t stride = step.innerRepeats;
+
+			for (size_t outerRepeat = 0; outerRepeat < step.outerRepeats; ++outerRepeat) {
+				RandomAccessIterator data = origData;
+				
+				const complex *twiddles = twiddleVector.data() + step.twiddleIndex;
+				const size_t factor = step.factor;
+				for (size_t repeat = 0; repeat < step.innerRepeats; ++repeat) {
+					for (size_t i = 0; i < step.factor; ++i) {
+						working[i] = _fft_impl::complexMul<inverse>(data[i*stride], twiddles[i]);
+					}
+					for (size_t f = 0; f < factor; ++f) {
+						complex sum = working[0];
+						for (size_t i = 1; i < factor; ++i) {
+							double phase = 2*M_PI*f*i/factor;
+							complex twiddle = {V(std::cos(phase)), V(-std::sin(phase))};
+							sum += _fft_impl::complexMul<inverse>(working[i], twiddle);
+						}
+						data[f*stride] = sum;
+					}
+					++data;
+					twiddles += factor;
+				}
+				origData += step.factor*step.innerRepeats;
+			}
+		}
+
+		template<bool inverse, typename RandomAccessIterator>
+		SIGNALSMITH_INLINE void fftStep2(RandomAccessIterator &&origData, const Step &step) {
+			const size_t stride = step.innerRepeats;
+			const complex *origTwiddles = twiddleVector.data() + step.twiddleIndex;
+			for (size_t outerRepeat = 0; outerRepeat < step.outerRepeats; ++outerRepeat) {
+				const complex* twiddles = origTwiddles;
+				for (RandomAccessIterator data = origData; data < origData + stride; ++data) {
+					complex A = data[0];
+					complex B = _fft_impl::complexMul<inverse>(data[stride], twiddles[1]);
+					
+					data[0] = A + B;
+					data[stride] = A - B;
+					twiddles += 2;
+				}
+				origData += 2*stride;
+			}
+		}
+
+		template<bool inverse, typename RandomAccessIterator>
+		SIGNALSMITH_INLINE void fftStep3(RandomAccessIterator &&origData, const Step &step) {
+			constexpr complex factor3 = {-0.5, inverse ? 0.8660254037844386 : -0.8660254037844386};
+			const size_t stride = step.innerRepeats;
+			const complex *origTwiddles = twiddleVector.data() + step.twiddleIndex;
+			
+			for (size_t outerRepeat = 0; outerRepeat < step.outerRepeats; ++outerRepeat) {
+				const complex* twiddles = origTwiddles;
+				for (RandomAccessIterator data = origData; data < origData + stride; ++data) {
+					complex A = data[0];
+					complex B = _fft_impl::complexMul<inverse>(data[stride], twiddles[1]);
+					complex C = _fft_impl::complexMul<inverse>(data[stride*2], twiddles[2]);
+					
+					complex realSum = A + (B + C)*factor3.real();
+					complex imagSum = (B - C)*factor3.imag();
+
+					data[0] = A + B + C;
+					data[stride] = _fft_impl::complexAddI<false>(realSum, imagSum);
+					data[stride*2] = _fft_impl::complexAddI<true>(realSum, imagSum);
+
+					twiddles += 3;
+				}
+				origData += 3*stride;
+			}
+		}
+
+		template<bool inverse, typename RandomAccessIterator>
+		SIGNALSMITH_INLINE void fftStep4(RandomAccessIterator &&origData, const Step &step) {
+			const size_t stride = step.innerRepeats;
+			const complex *origTwiddles = twiddleVector.data() + step.twiddleIndex;
+			
+			for (size_t outerRepeat = 0; outerRepeat < step.outerRepeats; ++outerRepeat) {
+				const complex* twiddles = origTwiddles;
+				for (RandomAccessIterator data = origData; data < origData + stride; ++data) {
+					complex A = data[0];
+					complex C = _fft_impl::complexMul<inverse>(data[stride], twiddles[2]);
+					complex B = _fft_impl::complexMul<inverse>(data[stride*2], twiddles[1]);
+					complex D = _fft_impl::complexMul<inverse>(data[stride*3], twiddles[3]);
+
+					complex sumAC = A + C, sumBD = B + D;
+					complex diffAC = A - C, diffBD = B - D;
+
+					data[0] = sumAC + sumBD;
+					data[stride] = _fft_impl::complexAddI<!inverse>(diffAC, diffBD);
+					data[stride*2] = sumAC - sumBD;
+					data[stride*3] = _fft_impl::complexAddI<inverse>(diffAC, diffBD);
+
+					twiddles += 4;
+				}
+				origData += 4*stride;
+			}
+		}
+		
+		template<typename InputIterator, typename OutputIterator>
+		void permute(InputIterator input, OutputIterator data) {
+			for (auto pair : permutation) {
+				data[pair.from] = input[pair.to];
+			}
+		}
+
+		template<bool inverse, typename InputIterator, typename OutputIterator>
+		void run(InputIterator &&input, OutputIterator &&data) {
+			permute(input, data);
+			
+			for (const Step &step : plan) {
+				switch (step.type) {
+					case StepType::generic:
+						fftStepGeneric<inverse>(data + step.startIndex, step);
+						break;
+					case StepType::step2:
+						fftStep2<inverse>(data + step.startIndex, step);
+						break;
+					case StepType::step3:
+						fftStep3<inverse>(data + step.startIndex, step);
+						break;
+					case StepType::step4:
+						fftStep4<inverse>(data + step.startIndex, step);
+						break;
+				}
+			}
+		}
+
+		static bool validSize(size_t size) {
+			constexpr static bool filter[32] = {
+				1, 1, 1, 1, 1, 0, 1, 0, 1, 1, // 0-9
+				0, 0, 1, 0, 0, 0, 1, 0, 1, 0, // 10-19
+				0, 0, 0, 0, 1, 0, 0, 0, 0, 0, // 20-29
+				0, 0
+			};
+			return filter[size];
+		}
+	public:
+		static size_t fastSizeAbove(size_t size) {
+			size_t power2 = 1;
+			while (size >= 32) {
+				size = (size - 1)/2 + 1;
+				power2 *= 2;
+			}
+			while (size < 32 && !validSize(size)) {
+				++size;
+			}
+			return power2*size;
+		}
+		static size_t fastSizeBelow(size_t size) {
+			size_t power2 = 1;
+			while (size >= 32) {
+				size /= 2;
+				power2 *= 2;
+			}
+			while (size > 1 && !validSize(size)) {
+				--size;
+			}
+			return power2*size;
+		}
+
+		FFT(size_t size, int fastDirection=0) : _size(0) {
+			if (fastDirection > 0) size = fastSizeAbove(size);
+			if (fastDirection < 0) size = fastSizeBelow(size);
+			this->setSize(size);
+		}
+
+		size_t setSize(size_t size) {
+			if (size != _size) {
+				_size = size;
+				workingVector.resize(size);
+				setPlan();
+			}
+			return _size;
+		}
+		size_t setFastSizeAbove(size_t size) {
+			return setSize(fastSizeAbove(size));
+		}
+		size_t setFastSizeBelow(size_t size) {
+			return setSize(fastSizeBelow(size));
+		}
+		const size_t & size() const {
+			return _size;
+		}
+
+		template<typename InputIterator, typename OutputIterator>
+		void fft(InputIterator &&input, OutputIterator &&output) {
+			auto inputIter = _fft_impl::GetIterator<InputIterator>::get(input);
+			auto outputIter = _fft_impl::GetIterator<OutputIterator>::get(output);
+			return run<false>(inputIter, outputIter);
+		}
+
+		template<typename InputIterator, typename OutputIterator>
+		void ifft(InputIterator &&input, OutputIterator &&output) {
+			auto inputIter = _fft_impl::GetIterator<InputIterator>::get(input);
+			auto outputIter = _fft_impl::GetIterator<OutputIterator>::get(output);
+			return run<true>(inputIter, outputIter);
+		}
+	};
+
+	struct FFTOptions {
+		static constexpr int halfFreqShift = 1;
+	};
+
+	template<typename V, int optionFlags=0>
+	class RealFFT {
+		static constexpr bool modified = (optionFlags&FFTOptions::halfFreqShift);
+
+		using complex = std::complex<V>;
+		std::vector<complex> complexBuffer1, complexBuffer2;
+		std::vector<complex> twiddlesMinusI;
+		std::vector<complex> modifiedRotations;
+		FFT<V> complexFft;
+	public:
+		static size_t fastSizeAbove(size_t size) {
+			return FFT<V>::fastSizeAbove((size + 1)/2)*2;
+		}
+		static size_t fastSizeBelow(size_t size) {
+			return FFT<V>::fastSizeBelow(size/2)*2;
+		}
+
+		RealFFT(size_t size=0, int fastDirection=0) : complexFft(0) {
+			if (fastDirection > 0) size = fastSizeAbove(size);
+			if (fastDirection < 0) size = fastSizeBelow(size);
+			this->setSize(std::max<size_t>(size, 2));
+		}
+
+		size_t setSize(size_t size) {
+			complexBuffer1.resize(size/2);
+			complexBuffer2.resize(size/2);
+
+			size_t hhSize = size/4 + 1;
+			twiddlesMinusI.resize(hhSize);
+			for (size_t i = 0; i < hhSize; ++i) {
+				V rotPhase = -2*M_PI*(modified ? i + 0.5 : i)/size;
+				twiddlesMinusI[i] = {std::sin(rotPhase), -std::cos(rotPhase)};
+			}
+			if (modified) {
+				modifiedRotations.resize(size/2);
+				for (size_t i = 0; i < size/2; ++i) {
+					V rotPhase = -2*M_PI*i/size;
+					modifiedRotations[i] = {std::cos(rotPhase), std::sin(rotPhase)};
+				}
+			}
+			
+			return complexFft.setSize(size/2);
+		}
+		size_t setFastSizeAbove(size_t size) {
+			return setSize(fastSizeAbove(size));
+		}
+		size_t setFastSizeBelow(size_t size) {
+			return setSize(fastSizeBelow(size));
+		}
+		size_t size() const {
+			return complexFft.size()*2;
+		}
+
+		template<typename InputIterator, typename OutputIterator>
+		void fft(InputIterator &&input, OutputIterator &&output) {
+			size_t hSize = complexFft.size();
+			for (size_t i = 0; i < hSize; ++i) {
+				if (modified) {
+					complexBuffer1[i] = _fft_impl::complexMul<false>({input[2*i], input[2*i + 1]}, modifiedRotations[i]);
+				} else {
+					complexBuffer1[i] = {input[2*i], input[2*i + 1]};
+				}
+			}
+			
+			complexFft.fft(complexBuffer1.data(), complexBuffer2.data());
+			
+			if (!modified) output[0] = {
+				complexBuffer2[0].real() + complexBuffer2[0].imag(),
+				complexBuffer2[0].real() - complexBuffer2[0].imag()
+			};
+			for (size_t i = modified ? 0 : 1; i <= hSize/2; ++i) {
+				size_t conjI = modified ? (hSize  - 1 - i) : (hSize - i);
+				
+				complex odd = (complexBuffer2[i] + conj(complexBuffer2[conjI]))*(V)0.5;
+				complex evenI = (complexBuffer2[i] - conj(complexBuffer2[conjI]))*(V)0.5;
+				complex evenRotMinusI = _fft_impl::complexMul<false>(evenI, twiddlesMinusI[i]);
+
+				output[i] = odd + evenRotMinusI;
+				output[conjI] = conj(odd - evenRotMinusI);
+			}
+		}
+
+		template<typename InputIterator, typename OutputIterator>
+		void ifft(InputIterator &&input, OutputIterator &&output) {
+			size_t hSize = complexFft.size();
+			if (!modified) complexBuffer1[0] = {
+				input[0].real() + input[0].imag(),
+				input[0].real() - input[0].imag()
+			};
+			for (size_t i = modified ? 0 : 1; i <= hSize/2; ++i) {
+				size_t conjI = modified ? (hSize  - 1 - i) : (hSize - i);
+				complex v = input[i], v2 = input[conjI];
+
+				complex odd = v + conj(v2);
+				complex evenRotMinusI = v - conj(v2);
+				complex evenI = _fft_impl::complexMul<true>(evenRotMinusI, twiddlesMinusI[i]);
+				
+				complexBuffer1[i] = odd + evenI;
+				complexBuffer1[conjI] = conj(odd - evenI);
+			}
+			
+			complexFft.ifft(complexBuffer1.data(), complexBuffer2.data());
+			
+			for (size_t i = 0; i < hSize; ++i) {
+				complex v = complexBuffer2[i];
+				if (modified) v = _fft_impl::complexMul<true>(v, modifiedRotations[i]);
+				output[2*i] = v.real();
+				output[2*i + 1] = v.imag();
+			}
+		}
+	};
+
+	template<typename V>
+	struct ModifiedRealFFT : public RealFFT<V, FFTOptions::halfFreqShift> {
+		using RealFFT<V, FFTOptions::halfFreqShift>::RealFFT;
+	};
+
+/// @}
+}} // namespace
+#endif // include guard

--- a/examples/dsp/filters.h
+++ b/examples/dsp/filters.h
@@ -1,0 +1,436 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_FILTERS_H
+#define SIGNALSMITH_DSP_FILTERS_H
+
+#include "./perf.h"
+
+#include <cmath>
+#include <complex>
+
+namespace signalsmith {
+namespace filters {
+	/**	@defgroup Filters Basic filters
+		@brief Classes for some common filter types
+		
+		@{
+		@file
+	*/
+	
+	/** Filter design methods.
+		These differ mostly in how they handle frequency-warping near Nyquist:
+		\diagram{filters-lowpass.svg}
+		\diagram{filters-highpass.svg}
+		\diagram{filters-peak.svg}
+		\diagram{filters-bandpass.svg}
+		\diagram{filters-notch.svg}
+		\diagram{filters-high-shelf.svg}
+		\diagram{filters-low-shelf.svg}
+		\diagram{filters-allpass.svg}
+	*/
+	enum class BiquadDesign {
+		bilinear, ///< Bilinear transform, adjusting for centre frequency but not bandwidth
+ 		cookbook, ///< RBJ's "Audio EQ Cookbook".  Based on `bilinear`, adjusting bandwidth (for peak/notch/bandpass) to preserve the ratio between upper/lower boundaries.  This performs oddly near Nyquist.
+		oneSided, ///< Based on `bilinear`, adjusting bandwidth to preserve the lower boundary (leaving the upper one loose).
+		vicanek ///< From Martin Vicanek's [Matched Second Order Digital Filters](https://vicanek.de/articles/BiquadFits.pdf).  Falls back to `oneSided` for shelf and allpass filters.  This takes the poles from the impulse-invariant approach, and then picks the zeros to create a better match.  This means that Nyquist is not 0dB for peak/notch (or -Inf for lowpass), but it is a decent match to the analogue prototype.
+	};
+	
+	/** A standard biquad.
+
+		This is not guaranteed to be stable if modulated at audio rate.
+		
+		The default highpass/lowpass bandwidth (`defaultBandwidth`) produces a Butterworth filter when bandwidth-compensation is disabled.
+		
+		Bandwidth compensation defaults to `BiquadDesign::oneSided` (or `BiquadDesign::cookbook` if `cookbookBandwidth` is enabled) for all filter types aside from highpass/lowpass (which use `BiquadDesign::bilinear`).*/
+	template<typename Sample, bool cookbookBandwidth=false>
+	class BiquadStatic {
+		static constexpr BiquadDesign bwDesign = cookbookBandwidth ? BiquadDesign::cookbook : BiquadDesign::oneSided;
+		Sample a1 = 0, a2 = 0, b0 = 1, b1 = 0, b2 = 0;
+		Sample x1 = 0, x2 = 0, y1 = 0, y2 = 0;
+		
+		enum class Type {highpass, lowpass, highShelf, lowShelf, bandpass, notch, peak, allpass};
+
+		struct FreqSpec {
+			double scaledFreq;
+			double w0, sinW0, cosW0;
+			double inv2Q;
+			
+			FreqSpec(double freq, BiquadDesign design) {
+				scaledFreq = std::max(1e-6, std::min(0.4999, freq));
+				if (design == BiquadDesign::cookbook) {
+					scaledFreq = std::min(0.45, scaledFreq);
+				}
+				w0 = 2*M_PI*scaledFreq;
+				cosW0 = std::cos(w0);
+				sinW0 = std::sin(w0);
+			}
+			
+			void oneSidedCompQ() {
+				// Ratio between our (digital) lower boundary f1 and centre f0
+				double f1Factor = std::sqrt(inv2Q*inv2Q + 1) - inv2Q;
+				// Bilinear means discrete-time freq f = continuous-time freq tan(pi*xf/pi)
+				double ctF1 = std::tan(M_PI*scaledFreq*f1Factor), invCtF0 = (1 + cosW0)/sinW0;
+				double ctF1Factor = ctF1*invCtF0;
+				inv2Q = 0.5/ctF1Factor - 0.5*ctF1Factor;
+			}
+		};
+		SIGNALSMITH_INLINE static FreqSpec octaveSpec(double scaledFreq, double octaves, BiquadDesign design) {
+			FreqSpec spec(scaledFreq, design);
+
+			if (design == BiquadDesign::cookbook) {
+				// Approximately preserves bandwidth between halfway points
+				octaves *= spec.w0/spec.sinW0;
+			}
+			spec.inv2Q = std::sinh(std::log(2)*0.5*octaves); // 1/(2Q)
+			if (design == BiquadDesign::oneSided) spec.oneSidedCompQ();
+			return spec;
+		}
+		SIGNALSMITH_INLINE static FreqSpec qSpec(double scaledFreq, double q, BiquadDesign design) {
+			FreqSpec spec(scaledFreq, design);
+
+			spec.inv2Q = 0.5/q;
+			if (design == BiquadDesign::oneSided) spec.oneSidedCompQ();
+			return spec;
+		}
+		
+		SIGNALSMITH_INLINE double dbToSqrtGain(double db) {
+			return std::pow(10, db*0.025);
+		}
+		
+		SIGNALSMITH_INLINE BiquadStatic & configure(Type type, FreqSpec calc, double sqrtGain, BiquadDesign design) {
+			double w0 = calc.w0;
+			
+			if (design == BiquadDesign::vicanek) {
+				if (type == Type::notch) { // Heuristic for notches near Nyquist
+					calc.inv2Q *= (1 - calc.scaledFreq*0.5);
+				}
+				double Q = (type == Type::peak ? 0.5*sqrtGain : 0.5)/calc.inv2Q;
+				double q = (type == Type::peak ? 1/sqrtGain : 1)*calc.inv2Q;
+				double expmqw = std::exp(-q*w0);
+				double da1, da2;
+				if (q <= 1) {
+					a1 = da1 = -2*expmqw*std::cos(std::sqrt(1 - q*q)*w0);
+				} else {
+					a1 = da1 = -2*expmqw*std::cosh(std::sqrt(q*q - 1)*w0);
+				}
+				a2 = da2 = expmqw*expmqw;
+				double sinpd2 = std::sin(w0/2);
+				double p0 = 1 - sinpd2*sinpd2, p1 = sinpd2*sinpd2, p2 = 4*p0*p1;
+				double A0 = 1 + da1 + da2, A1 = 1 - da1 + da2, A2 = -4*da2;
+				A0 *= A0;
+				A1 *= A1;
+				if (type == Type::lowpass) {
+					double R1 = (A0*p0 + A1*p1 + A2*p2)*Q*Q;
+					double B0 = A0, B1 = (R1 - B0*p0)/p1;
+					b0 = 0.5*(std::sqrt(B0) + std::sqrt(std::max(0.0, B1)));
+					b1 = std::sqrt(B0) - b0;
+					b2 = 0;
+					return *this;
+				} else if (type == Type::highpass) {
+					b2 = b0 = std::sqrt(A0*p0 + A1*p1 + A2*p2)*Q/(4*p1);
+					b1 = -2*b0;
+					return *this;
+				} else if (type == Type::bandpass) {
+					double R1 = A0*p0 + A1*p1 + A2*p2;
+					double R2 = -A0 + A1 + 4*(p0 - p1)*A2;
+					double B2 = (R1 - R2*p1)/(4*p1*p1);
+					double B1 = R2 + 4*(p1 - p0)*B2;
+					b1 = -0.5*std::sqrt(std::max(0.0, B1));
+					b0 = 0.5*(std::sqrt(std::max(0.0, B2 + 0.25*B1)) - b1);
+					b2 = -b0 - b1;
+					return *this;
+				} else if (type == Type::notch) {
+					// The Vicanek paper doesn't cover notches (band-stop), but we know where the zeros should be:
+					b0 = 1;
+					double db1 = -2*std::cos(w0); // might be higher precision
+					b1 = db1;
+					b2 = 1;
+					// Scale so that B0 == A0 to get 0dB at f=0
+					double scale = std::sqrt(A0)/(b0 + db1 + b2);
+					b0 *= scale;
+					b1 *= scale;
+					b2 *= scale;
+					return *this;
+				} else if (type == Type::peak) {
+					double G2 = (sqrtGain*sqrtGain)*(sqrtGain*sqrtGain);
+					double R1 = (A0*p0 + A1*p1 + A2*p2)*G2;
+					double R2 = (-A0 + A1 + 4*(p0 - p1)*A2)*G2;
+					double B0 = A0;
+					double B2 = (R1 - R2*p1 - B0)/(4*p1*p1);
+					double B1 = R2 + B0 + 4*(p1 - p0)*B2;
+					double W = 0.5*(std::sqrt(B0) + std::sqrt(std::max(0.0, B1)));
+					b0 = 0.5*(W + std::sqrt(std::max(0.0, W*W + B2)));
+					b1 = 0.5*(std::sqrt(B0) - std::sqrt(std::max(0.0, B1)));
+					b2 = -B2/(4*b0);
+					return *this;
+				}
+				// All others fall back to `oneSided`
+				design = BiquadDesign::oneSided;
+				calc.oneSidedCompQ();
+			}
+
+			double alpha = calc.sinW0*calc.inv2Q;
+			double A = sqrtGain, sqrtA2alpha = 2*std::sqrt(A)*alpha;
+
+			double a0;
+			if (type == Type::highpass) {
+				b1 = -1 - calc.cosW0;
+				b0 = b2 = (1 + calc.cosW0)*0.5;
+				a0 = 1 + alpha;
+				a1 = -2*calc.cosW0;
+				a2 = 1 - alpha;
+			} else if (type == Type::lowpass) {
+				b1 = 1 - calc.cosW0;
+				b0 = b2 = b1*0.5;
+				a0 = 1 + alpha;
+				a1 = -2*calc.cosW0;
+				a2 = 1 - alpha;
+			} else if (type == Type::highShelf) {
+				b0 = A*((A+1)+(A-1)*calc.cosW0+sqrtA2alpha);
+				b2 = A*((A+1)+(A-1)*calc.cosW0-sqrtA2alpha);
+				b1 = -2*A*((A-1)+(A+1)*calc.cosW0);
+				a0 = (A+1)-(A-1)*calc.cosW0+sqrtA2alpha;
+				a2 = (A+1)-(A-1)*calc.cosW0-sqrtA2alpha;
+				a1 = 2*((A-1)-(A+1)*calc.cosW0);
+			} else if (type == Type::lowShelf) {
+				b0 = A*((A+1)-(A-1)*calc.cosW0+sqrtA2alpha);
+				b2 = A*((A+1)-(A-1)*calc.cosW0-sqrtA2alpha);
+				b1 = 2*A*((A-1)-(A+1)*calc.cosW0);
+				a0 = (A+1)+(A-1)*calc.cosW0+sqrtA2alpha;
+				a2 = (A+1)+(A-1)*calc.cosW0-sqrtA2alpha;
+				a1 = -2*((A-1)+(A+1)*calc.cosW0);
+			} else if (type == Type::bandpass) {
+				b0 = alpha;
+				b1 = 0;
+				b2 = -alpha;
+				a0 = 1 + alpha;
+				a1 = -2*calc.cosW0;
+				a2 = 1 - alpha;
+			} else if (type == Type::notch) {
+				b0 = 1;
+				b1 = -2*calc.cosW0;
+				b2 = 1;
+				a0 = 1 + alpha;
+				a1 = b1;
+				a2 = 1 - alpha;
+			} else if (type == Type::peak) {
+				b0 = 1 + alpha*A;
+				b1 = -2*calc.cosW0;
+				b2 = 1 - alpha*A;
+				a0 = 1 + alpha/A;
+				a1 = b1;
+				a2 = 1 - alpha/A;
+			} else if (type == Type::allpass) {
+				a0 = b2 = 1 + alpha;
+				a1 = b1 = -2*calc.cosW0;
+				a2 = b0 = 1 - alpha;
+			} else {
+				// reset to neutral
+				a1 = a2 = b1 = b2 = 0;
+				a0 = b0 = 1;
+			}
+			double invA0 = 1/a0;
+			b0 *= invA0;
+			b1 *= invA0;
+			b2 *= invA0;
+			a1 *= invA0;
+			a2 *= invA0;
+			return *this;
+		}
+	public:
+		static constexpr double defaultQ = 0.7071067811865476; // sqrt(0.5)
+		static constexpr double defaultBandwidth = 1.8999686269529916; // equivalent to above Q
+
+		Sample operator ()(Sample x0) {
+			Sample y0 = x0*b0 + x1*b1 + x2*b2 - y1*a1 - y2*a2;
+			y2 = y1;
+			y1 = y0;
+			x2 = x1;
+			x1 = x0;
+			return y0;
+		}
+		
+		void reset() {
+			x1 = x2 = y1 = y2 = 0;
+		}
+		
+		std::complex<Sample> response(Sample scaledFreq) const {
+			Sample w = scaledFreq*Sample(2*M_PI);
+			std::complex<Sample> invZ = {std::cos(w), -std::sin(w)}, invZ2 = invZ*invZ;
+			return (b0 + invZ*b1 + invZ2*b2)/(Sample(1) + invZ*a1 + invZ2*a2);
+		}
+		Sample responseDb(Sample scaledFreq) const {
+			Sample w = scaledFreq*Sample(2*M_PI);
+			std::complex<Sample> invZ = {std::cos(w), -std::sin(w)}, invZ2 = invZ*invZ;
+			Sample energy = std::norm(b0 + invZ*b1 + invZ2*b2)/std::norm(Sample(1) + invZ*a1 + invZ2*a2);
+			return 10*std::log10(energy);
+		}
+
+		/// @name Lowpass
+		/// @{
+		BiquadStatic & lowpass(double scaledFreq, double octaves=defaultBandwidth, BiquadDesign design=BiquadDesign::bilinear) {
+			return configure(Type::lowpass, octaveSpec(scaledFreq, octaves, design), 0, design);
+		}
+		BiquadStatic & lowpassQ(double scaledFreq, double q, BiquadDesign design=BiquadDesign::bilinear) {
+			return configure(Type::lowpass, qSpec(scaledFreq, q, design), 0, design);
+		}
+		/// @deprecated use `BiquadDesign` instead
+		void lowpass(double scaledFreq, double octaves, bool correctBandwidth) {
+			lowpass(scaledFreq, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @deprecated By the time you care about `design`, you should care about the bandwidth
+		BiquadStatic & lowpass(double scaledFreq, BiquadDesign design) {
+			return lowpass(scaledFreq, defaultBandwidth, design);
+		}
+		/// @}
+		
+		/// @name Highpass
+		/// @{
+		BiquadStatic & highpass(double scaledFreq, double octaves=defaultBandwidth, BiquadDesign design=BiquadDesign::bilinear) {
+			return configure(Type::highpass, octaveSpec(scaledFreq, octaves, design), 0, design);
+		}
+		BiquadStatic & highpassQ(double scaledFreq, double q, BiquadDesign design=BiquadDesign::bilinear) {
+			return configure(Type::highpass, qSpec(scaledFreq, q, design), 0, design);
+		}
+		/// @deprecated use `BiquadDesign` instead
+		void highpass(double scaledFreq, double octaves, bool correctBandwidth) {
+			highpass(scaledFreq, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @deprecated By the time you care about `design`, you should care about the bandwidth
+		BiquadStatic & highpass(double scaledFreq, BiquadDesign design) {
+			return highpass(scaledFreq, defaultBandwidth, design);
+		}
+		/// @}
+
+		/// @name Bandpass
+		/// @{
+		BiquadStatic & bandpass(double scaledFreq, double octaves=defaultBandwidth, BiquadDesign design=bwDesign) {
+			return configure(Type::bandpass, octaveSpec(scaledFreq, octaves, design), 0, design);
+		}
+		BiquadStatic & bandpassQ(double scaledFreq, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::bandpass, qSpec(scaledFreq, q, design), 0, design);
+		}
+		/// @deprecated use `BiquadDesign` instead
+		void bandpass(double scaledFreq, double octaves, bool correctBandwidth) {
+			bandpass(scaledFreq, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @deprecated By the time you care about `design`, you should care about the bandwidth
+		BiquadStatic & bandpass(double scaledFreq, BiquadDesign design) {
+			return bandpass(scaledFreq, defaultBandwidth, design);
+		}
+		/// @}
+
+		/// @name Notch
+		/// @{
+		BiquadStatic & notch(double scaledFreq, double octaves=defaultBandwidth, BiquadDesign design=bwDesign) {
+			return configure(Type::notch, octaveSpec(scaledFreq, octaves, design), 0, design);
+		}
+		BiquadStatic & notchQ(double scaledFreq, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::notch, qSpec(scaledFreq, q, design), 0, design);
+		}
+		/// @deprecated use `BiquadDesign` instead
+		void notch(double scaledFreq, double octaves, bool correctBandwidth) {
+			notch(scaledFreq, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @deprecated By the time you care about `design`, you should care about the bandwidth
+		BiquadStatic & notch(double scaledFreq, BiquadDesign design) {
+			return notch(scaledFreq, defaultBandwidth, design);
+		}
+		/// @deprecated alias for `.notch()`
+		void bandStop(double scaledFreq, double octaves=1, bool correctBandwidth=true) {
+			notch(scaledFreq, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @}
+
+		/// @name Peak
+		/// @{
+		BiquadStatic & peak(double scaledFreq, double gain, double octaves=1, BiquadDesign design=bwDesign) {
+			return configure(Type::peak, octaveSpec(scaledFreq, octaves, design), std::sqrt(gain), design);
+		}
+		BiquadStatic & peakDb(double scaledFreq, double db, double octaves=1, BiquadDesign design=bwDesign) {
+			return configure(Type::peak, octaveSpec(scaledFreq, octaves, design), dbToSqrtGain(db), design);
+		}
+		BiquadStatic & peakQ(double scaledFreq, double gain, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::peak, qSpec(scaledFreq, q, design), std::sqrt(gain), design);
+		}
+		BiquadStatic & peakDbQ(double scaledFreq, double db, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::peak, qSpec(scaledFreq, q, design), dbToSqrtGain(db), design);
+		}
+		/// @deprecated By the time you care about `design`, you should care about the bandwidth
+		BiquadStatic & peak(double scaledFreq, double gain, BiquadDesign design) {
+			return peak(scaledFreq, gain, 1, design);
+		}
+		/// @}
+
+		/// @name High shelf
+		/// @{
+		BiquadStatic & highShelf(double scaledFreq, double gain, double octaves=defaultBandwidth, BiquadDesign design=bwDesign) {
+			return configure(Type::highShelf, octaveSpec(scaledFreq, octaves, design), std::sqrt(gain), design);
+		}
+		BiquadStatic & highShelfDb(double scaledFreq, double db, double octaves=defaultBandwidth, BiquadDesign design=bwDesign) {
+			return configure(Type::highShelf, octaveSpec(scaledFreq, octaves, design), dbToSqrtGain(db), design);
+		}
+		BiquadStatic & highShelfQ(double scaledFreq, double gain, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::highShelf, qSpec(scaledFreq, q, design), std::sqrt(gain), design);
+		}
+		BiquadStatic & highShelfDbQ(double scaledFreq, double db, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::highShelf, qSpec(scaledFreq, q, design), dbToSqrtGain(db), design);
+		}
+		/// @deprecated use `BiquadDesign` instead
+		BiquadStatic & highShelf(double scaledFreq, double gain, double octaves, bool correctBandwidth) {
+			return highShelf(scaledFreq, gain, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @deprecated use `BiquadDesign` instead
+		BiquadStatic & highShelfDb(double scaledFreq, double db, double octaves, bool correctBandwidth) {
+			return highShelfDb(scaledFreq, db, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @}
+
+		/// @name Low shelf
+		/// @{
+		BiquadStatic & lowShelf(double scaledFreq, double gain, double octaves=2, BiquadDesign design=bwDesign) {
+			return configure(Type::lowShelf, octaveSpec(scaledFreq, octaves, design), std::sqrt(gain), design);
+		}
+		BiquadStatic & lowShelfDb(double scaledFreq, double db, double octaves=2, BiquadDesign design=bwDesign) {
+			return configure(Type::lowShelf, octaveSpec(scaledFreq, octaves, design), dbToSqrtGain(db), design);
+		}
+		BiquadStatic & lowShelfQ(double scaledFreq, double gain, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::lowShelf, qSpec(scaledFreq, q, design), std::sqrt(gain), design);
+		}
+		BiquadStatic & lowShelfDbQ(double scaledFreq, double db, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::lowShelf, qSpec(scaledFreq, q, design), dbToSqrtGain(db), design);
+		}
+		/// @deprecated use `BiquadDesign` instead
+		BiquadStatic & lowShelf(double scaledFreq, double gain, double octaves, bool correctBandwidth) {
+			return lowShelf(scaledFreq, gain, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @deprecated use `BiquadDesign` instead
+		BiquadStatic & lowShelfDb(double scaledFreq, double db, double octaves, bool correctBandwidth) {
+			return lowShelfDb(scaledFreq, db, octaves, correctBandwidth ? bwDesign : BiquadDesign::bilinear);
+		}
+		/// @}
+		
+		/// @name Allpass
+		/// @{
+		BiquadStatic & allpass(double scaledFreq, double octaves=1, BiquadDesign design=bwDesign) {
+			return configure(Type::allpass, octaveSpec(scaledFreq, octaves, design), 0, design);
+		}
+		BiquadStatic & allpassQ(double scaledFreq, double q, BiquadDesign design=bwDesign) {
+			return configure(Type::allpass, qSpec(scaledFreq, q, design), 0, design);
+		}
+		/// @}
+
+		BiquadStatic & addGain(double factor) {
+			b0 *= factor;
+			b1 *= factor;
+			b2 *= factor;
+			return *this;
+		}
+		BiquadStatic & addGainDb(double db) {
+			return addGain(std::pow(10, db*0.05));
+		}
+	};
+
+	/** @} */
+}} // signalsmith::filters::
+#endif // include guard

--- a/examples/dsp/mix.h
+++ b/examples/dsp/mix.h
@@ -1,0 +1,218 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_MULTI_CHANNEL_H
+#define SIGNALSMITH_DSP_MULTI_CHANNEL_H
+
+#include <array>
+
+namespace signalsmith {
+namespace mix {
+	/**	@defgroup Mix Multichannel mixing
+		@brief Utilities for stereo/multichannel mixing operations
+
+		@{
+		@file
+	*/
+
+	/** @defgroup Matrices Orthogonal matrices
+		@brief Some common matrices used for audio
+		@ingroup Mix
+		@{ */
+
+	/// @brief Hadamard: high mixing levels, N log(N) operations
+	template<typename Sample, int size=-1>
+	class Hadamard {
+	public:
+		static_assert(size >= 0, "Size must be positive (or -1 for dynamic)");
+		/// Applies the matrix, scaled so it's orthogonal
+		template<class Data>
+		static void inPlace(Data &&data) {
+			unscaledInPlace(data);
+			
+			Sample factor = scalingFactor();
+			for (int c = 0; c < size; ++c) {
+				data[c] *= factor;
+			}
+		}
+
+		/// Scaling factor applied to make it orthogonal
+		static Sample scalingFactor() {
+			/// TODO: test for C++20, or whatever makes this constexpr.  Maybe a `#define` in `common.h`?
+			return std::sqrt(Sample(1)/(size ? size : 1));
+		}
+
+		/// Skips the scaling, so it's a matrix full of `1`s
+		template<class Data, int startIndex=0>
+		static void unscaledInPlace(Data &&data) {
+			if (size <= 1) return;
+			constexpr int hSize = size/2;
+
+			Hadamard<Sample, hSize>::template unscaledInPlace<Data, startIndex>(data);
+			Hadamard<Sample, hSize>::template unscaledInPlace<Data, startIndex + hSize>(data);
+
+			for (int i = 0; i < hSize; ++i) {
+				Sample a = data[i + startIndex], b = data[i + startIndex + hSize];
+				data[i + startIndex] = (a + b);
+				data[i + startIndex + hSize] = (a - b);
+			}
+		}
+	};
+	/// @brief Hadamard with dynamic size
+	template<typename Sample>
+	class Hadamard<Sample, -1> {
+		int size;
+	public:
+		Hadamard(int size) : size(size) {}
+		
+		/// Applies the matrix, scaled so it's orthogonal
+		template<class Data>
+		void inPlace(Data &&data) const {
+			unscaledInPlace(data);
+			
+			Sample factor = scalingFactor();
+			for (int c = 0; c < size; ++c) {
+				data[c] *= factor;
+			}
+		}
+
+		/// Scaling factor applied to make it orthogonal
+		Sample scalingFactor() const {
+			return std::sqrt(Sample(1)/(size ? size : 1));
+		}
+
+		/// Skips the scaling, so it's a matrix full of `1`s
+		template<class Data>
+		void unscaledInPlace(Data &&data) const {
+			int hSize = size/2;
+			while (hSize > 0) {
+				for (int startIndex = 0; startIndex < size; startIndex += hSize*2) {
+					for (int i = startIndex; i < startIndex + hSize; ++i) {
+						Sample a = data[i], b = data[i + hSize];
+						data[i] = (a + b);
+						data[i + hSize] = (a - b);
+					}
+				}
+				hSize /= 2;
+			}
+		}
+	};
+	/// @brief Householder: moderate mixing, 2N operations
+	template<typename Sample, int size=-1>
+	class Householder {
+	public:
+		static_assert(size >= 0, "Size must be positive (or -1 for dynamic)");
+		template<class Data>
+		static void inPlace(Data &&data) {
+			if (size < 1) return;
+			/// TODO: test for C++20, which makes `std::complex::operator/` constexpr
+			const Sample factor = Sample(-2)/Sample(size ? size : 1);
+
+			Sample sum = data[0];
+			for (int i = 1; i < size; ++i) {
+				sum += data[i];
+			}
+			sum *= factor;
+			for (int i = 0; i < size; ++i) {
+				data[i] += sum;
+			}
+		}
+		/// @deprecated The matrix is already orthogonal, but this is here for compatibility with Hadamard
+		constexpr static Sample scalingFactor() {
+			return 1;
+		}
+	};
+	/// @brief Householder with dynamic size
+	template<typename Sample>
+	class Householder<Sample, -1> {
+		int size;
+	public:
+		Householder(int size) : size(size) {}
+	
+		template<class Data>
+		void inPlace(Data &&data) const {
+			if (size < 1) return;
+			const Sample factor = Sample(-2)/Sample(size ? size : 1);
+
+			Sample sum = data[0];
+			for (int i = 1; i < size; ++i) {
+				sum += data[i];
+			}
+			sum *= factor;
+			for (int i = 0; i < size; ++i) {
+				data[i] += sum;
+			}
+		}
+		/// @deprecated The matrix is already orthogonal, but this is here for compatibility with Hadamard
+		constexpr static Sample scalingFactor() {
+			return 1;
+		}
+	};
+	///  @}
+	
+	/** @brief Upmix/downmix a stereo signal to an (even) multi-channel signal
+		
+		When spreading out, it rotates the input by various amounts (e.g. a four-channel signal would produce `(left, right, mid side)`), such that energy is preserved for each pair.
+		
+		When mixing together, it uses the opposite rotations, such that upmix → downmix produces the same stereo signal (when scaled by `.scalingFactor1()`.
+	*/
+	template<typename Sample, int channels>
+	class StereoMultiMixer {
+		static_assert((channels/2)*2 == channels, "StereoMultiMixer must have an even number of channels");
+		static_assert(channels > 0, "StereoMultiMixer must have a positive number of channels");
+		static constexpr int hChannels = channels/2;
+		std::array<Sample, channels> coeffs;
+	public:
+		StereoMultiMixer() {
+			coeffs[0] = 1;
+			coeffs[1] = 0;
+			for (int i = 1; i < hChannels; ++i) {
+				double phase = M_PI*i/channels;
+				coeffs[2*i] = std::cos(phase);
+				coeffs[2*i + 1] = std::sin(phase);
+			}
+		}
+		
+		template<class In, class Out>
+		void stereoToMulti(In &input, Out &output) const {
+			output[0] = input[0];
+			output[1] = input[1];
+			for (int i = 2; i < channels; i += 2) {
+				output[i] = input[0]*coeffs[i] + input[1]*coeffs[i + 1];
+				output[i + 1] = input[1]*coeffs[i] - input[0]*coeffs[i + 1];
+			}
+		}
+		template<class In, class Out>
+		void multiToStereo(In &input, Out &output) const {
+			output[0] = input[0];
+			output[1] = input[1];
+			for (int i = 2; i < channels; i += 2) {
+				output[0] += input[i]*coeffs[i] - input[i + 1]*coeffs[i + 1];
+				output[1] += input[i + 1]*coeffs[i] + input[i]*coeffs[i + 1];
+			}
+		}
+		/// Scaling factor for the downmix, if channels are phase-aligned
+		static constexpr Sample scalingFactor1() {
+			return 2/Sample(channels);
+		}
+		/// Scaling factor for the downmix, if channels are independent
+		static Sample scalingFactor2() {
+			return std::sqrt(scalingFactor1());
+		}
+	};
+	
+	/// A cheap (polynomial) almost-energy-preserving crossfade
+	/// Maximum energy error: 1.06%, average 0.64%, curves overshoot by 0.3%
+	/// See: http://signalsmith-audio.co.uk/writing/2021/cheap-energy-crossfade/
+	template<typename Sample, typename Result>
+	void cheapEnergyCrossfade(Sample x, Result &toCoeff, Result &fromCoeff) {
+		Sample x2 = 1 - x;
+		// Other powers p can be approximated by: k = -6.0026608 + p*(6.8773512 - 1.5838104*p)
+		Sample A = x*x2, B = A*(1 + (Sample)1.4186*A);
+		Sample C = (B + x), D = (B + x2);
+		toCoeff = C*C;
+		fromCoeff = D*D;
+	}
+
+/** @} */
+}} // signalsmith::delay::
+#endif // include guard

--- a/examples/dsp/perf.h
+++ b/examples/dsp/perf.h
@@ -1,0 +1,84 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_PERF_H
+#define SIGNALSMITH_DSP_PERF_H
+
+#include <complex>
+
+#if defined(__SSE__) || defined(_M_X64)
+#	include <xmmintrin.h>
+#else
+#	include <cstdint> // for uintptr_t
+#endif
+
+namespace signalsmith {
+namespace perf {
+	/**	@defgroup Performance Performance helpers
+		@brief Nothing serious, just some `#defines` and helpers
+		
+		@{
+		@file
+	*/
+		
+	/// *Really* insist that a function/method is inlined (mostly for performance in DEBUG builds)
+	#ifndef SIGNALSMITH_INLINE
+	#ifdef __GNUC__
+	#define SIGNALSMITH_INLINE __attribute__((always_inline)) inline
+	#elif defined(__MSVC__)
+	#define SIGNALSMITH_INLINE __forceinline inline
+	#else
+	#define SIGNALSMITH_INLINE inline
+	#endif
+	#endif
+
+	/** @brief Complex-multiplication (with optional conjugate second-arg), without handling NaN/Infinity
+		The `std::complex` multiplication has edge-cases around NaNs which slow things down and prevent auto-vectorisation.  Flags like `-ffast-math` sort this out anyway, but this helps with Debug builds.
+	*/
+	template <bool conjugateSecond=false, typename V>
+	SIGNALSMITH_INLINE static std::complex<V> mul(const std::complex<V> &a, const std::complex<V> &b) {
+		return conjugateSecond ? std::complex<V>{
+			b.real()*a.real() + b.imag()*a.imag(),
+			b.real()*a.imag() - b.imag()*a.real()
+		} : std::complex<V>{
+			a.real()*b.real() - a.imag()*b.imag(),
+			a.real()*b.imag() + a.imag()*b.real()
+		};
+	}
+
+#if defined(__SSE__) || defined(_M_X64)
+	class StopDenormals {
+		unsigned int controlStatusRegister;
+	public:
+		StopDenormals() : controlStatusRegister(_mm_getcsr()) {
+			_mm_setcsr(controlStatusRegister|0x8040); // Flush-to-Zero and Denormals-Are-Zero
+		}
+		~StopDenormals() {
+			_mm_setcsr(controlStatusRegister);
+		}
+	};
+#elif (defined (__ARM_NEON) || defined (__ARM_NEON__))
+	class StopDenormals {
+		uintptr_t status;
+	public:
+		StopDenormals() {
+			uintptr_t asmStatus;
+			asm volatile("mrs %0, fpcr" : "=r"(asmStatus));
+			status = asmStatus = asmStatus|0x01000000U; // Flush to Zero
+			asm volatile("msr fpcr, %0" : : "ri"(asmStatus));
+		}
+		~StopDenormals() {
+			uintptr_t asmStatus = status;
+			asm volatile("msr fpcr, %0" : : "ri"(asmStatus));
+		}
+	};
+#else
+#	if __cplusplus >= 202302L
+# 		warning "The `StopDenormals` class doesn't do anything for this architecture"
+#	endif
+	class StopDenormals {}; // FIXME: add for other architectures
+#endif
+
+/** @} */
+}} // signalsmith::perf::
+
+#endif // include guard

--- a/examples/dsp/rates.h
+++ b/examples/dsp/rates.h
@@ -1,0 +1,184 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_RATES_H
+#define SIGNALSMITH_DSP_RATES_H
+
+#include "./windows.h"
+#include "./delay.h"
+
+namespace signalsmith {
+namespace rates {
+	/**	@defgroup Rates Multi-rate processing
+		@brief Classes for oversampling/upsampling/downsampling etc.
+
+		@{
+		@file
+	*/
+	
+	/// @brief Fills a container with a Kaiser-windowed sinc for an FIR lowpass.
+	/// \diagram{rates-kaiser-sinc.svg,33-point results for various pass/stop frequencies}
+	template<class Data>
+	void fillKaiserSinc(Data &&data, int length, double passFreq, double stopFreq) {
+		if (length <= 0) return;
+		double kaiserBandwidth = (stopFreq - passFreq)*length;
+		kaiserBandwidth += 1.25/kaiserBandwidth; // heuristic for transition band, see `InterpolatorKaiserSincN`
+		auto kaiser = signalsmith::windows::Kaiser::withBandwidth(kaiserBandwidth);
+		kaiser.fill(data, length);
+
+		double centreIndex = (length - 1)*0.5;
+		double sincScale = M_PI*(passFreq + stopFreq);
+		double ampScale = (passFreq + stopFreq);
+		for (int i = 0; i < length; ++i) {
+			double x = (i - centreIndex), px = x*sincScale;
+			double sinc = (std::abs(px) > 1e-6) ? std::sin(px)*ampScale/px : ampScale;
+			data[i] *= sinc;
+		}
+	};
+	/// @brief If only the centre frequency is specified, a heuristic is used to balance ripples and transition width
+	/// \diagram{rates-kaiser-sinc-heuristic.svg,The transition width is set to: 0.9/sqrt(length)}
+	template<class Data>
+	void fillKaiserSinc(Data &&data, int length, double centreFreq) {
+		double halfWidth = 0.45/std::sqrt(length);
+		if (halfWidth > centreFreq) halfWidth = (halfWidth + centreFreq)*0.5;
+		fillKaiserSinc(data, length, centreFreq - halfWidth, centreFreq + halfWidth);
+	}
+
+	/** 2x FIR oversampling for block-based processing.
+ 
+		\diagram{rates-oversampler2xfir-responses-45.svg,Upsample response for various lengths}
+	
+		The oversampled signal is stored inside this object, with channels accessed via `oversampler[c]`.  For example, you might do:
+		\code{.cpp}
+			// Upsample from multi-channel input (inputBuffers[c][i] is a sample)
+			oversampler.up(inputBuffers, bufferLength)
+			
+			// Modify the contents at the higher rate
+			for (int c = 0; c < 2; ++c) {
+				float *channel = oversampler[c];
+				for (int i = 0; i < bufferLength*2; ++i) {
+					channel[i] = std::abs(channel[i]);
+				}
+			}
+			
+			// Downsample into the multi-channel output
+			oversampler.down(outputBuffers, bufferLength);
+		\endcode
+
+		The performance depends not just on the length, but also on where you end the passband, allowing a wider/narrower transition band.  Frequencies above this limit (relative to the lower sample-rate) may alias when upsampling and downsampling.
+
+		\diagram{rates-oversampler2xfir-lengths.svg,Resample error rates for different passband thresholds}
+	
+		Since both upsample and downsample are stateful, channels are meaningful.  If your input channel-count doesn't match your output, you can size it to the larger of the two, and use `.upChannel()` and `.downChannel()` to only process the channels which exist.*/
+	template<typename Sample>
+	struct Oversampler2xFIR {
+		Oversampler2xFIR() : Oversampler2xFIR(0, 0) {}
+		Oversampler2xFIR(int channels, int maxBlock, int halfLatency=16, double passFreq=0.43) {
+			resize(channels, maxBlock, halfLatency, passFreq);
+		}
+		
+		void resize(int nChannels, int maxBlockLength) {
+			resize(nChannels, maxBlockLength, oneWayLatency);
+		}
+		void resize(int nChannels, int maxBlockLength, int halfLatency, double passFreq=0.43) {
+			oneWayLatency = halfLatency;
+			kernelLength = oneWayLatency*2;
+			channels = nChannels;
+			halfSampleKernel.resize(kernelLength);
+			fillKaiserSinc(halfSampleKernel, kernelLength, passFreq, 1 - passFreq);
+			inputStride = kernelLength + maxBlockLength;
+			inputBuffer.resize(channels*inputStride);
+			stride = (maxBlockLength + kernelLength)*2;
+			buffer.resize(stride*channels);
+		}
+
+		void reset() {
+			inputBuffer.assign(inputBuffer.size(), 0);
+			buffer.assign(buffer.size(), 0);
+		}
+
+		/// @brief Round-trip latency (or equivalently: upsample latency at the higher rate).
+		/// This will be twice the value passed into the constructor or `.resize()`.
+		int latency() const {
+			return kernelLength;
+		}
+		
+		/// Upsamples from a multi-channel input into the internal buffer
+		template<class Data>
+		void up(Data &&data, int lowSamples) {
+			for (int c = 0; c < channels; ++c) {
+				upChannel(c, data[c], lowSamples);
+			}
+		}
+
+		/// Upsamples a single-channel input into the internal buffer
+		template<class Data>
+		void upChannel(int c, Data &&data, int lowSamples) {
+			Sample *inputChannel = inputBuffer.data() + c*inputStride;
+			for (int i = 0; i < lowSamples; ++i) {
+				inputChannel[kernelLength + i] = data[i];
+			}
+			Sample *output = (*this)[c];
+			for (int i = 0; i < lowSamples; ++i) {
+				output[2*i] = inputChannel[i + oneWayLatency];
+				Sample *offsetInput = inputChannel + (i + 1);
+				Sample sum = 0;
+				for (int o = 0; o < kernelLength; ++o) {
+					sum += offsetInput[o]*halfSampleKernel[o];
+				}
+				output[2*i + 1] = sum;
+			}
+			// Copy the end of the buffer back to the beginning
+			for (int i = 0; i < kernelLength; ++i) {
+				inputChannel[i] = inputChannel[lowSamples + i];
+			}
+		}
+
+		/// Downsamples from the internal buffer to a multi-channel output
+		template<class Data>
+		void down(Data &&data, int lowSamples) {
+			for (int c = 0; c < channels; ++c) {
+				downChannel(c, data[c], lowSamples);
+			}
+		}
+
+		/// Downsamples a single channel from the internal buffer to a single-channel output
+		template<class Data>
+		void downChannel(int c, Data &&data, int lowSamples) {
+			Sample *input = buffer.data() + c*stride; // no offset for latency
+			for (int i = 0; i < lowSamples; ++i) {
+				Sample v1 = input[2*i + kernelLength];
+				Sample sum = 0;
+				for (int o = 0; o < kernelLength; ++o) {
+					Sample v2 = input[2*(i + o) + 1];
+					sum += v2*halfSampleKernel[o];
+				}
+				Sample v2 = sum;
+				Sample v = (v1 + v2)*Sample(0.5);
+				data[i] = v;
+			}
+			// Copy the end of the buffer back to the beginning
+			for (int i = 0; i < kernelLength*2; ++i) {
+				input[i] = input[lowSamples*2 + i];
+			}
+		}
+
+		/// Gets the samples for a single (higher-rate) channel.  The valid length depends how many input samples were passed into `.up()`/`.upChannel()`.
+		Sample * operator[](int c) {
+			return buffer.data() + kernelLength*2 + stride*c;
+		}
+		const Sample * operator[](int c) const {
+			return buffer.data() + kernelLength*2 + stride*c;
+		}
+
+	private:
+		int oneWayLatency, kernelLength;
+		int channels;
+		int stride, inputStride;
+		std::vector<Sample> inputBuffer;
+		std::vector<Sample> halfSampleKernel;
+		std::vector<Sample> buffer;
+	};
+
+/** @} */
+}} // namespace
+#endif // include guard

--- a/examples/dsp/spectral.h
+++ b/examples/dsp/spectral.h
@@ -1,0 +1,492 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_SPECTRAL_H
+#define SIGNALSMITH_DSP_SPECTRAL_H
+
+#include "./perf.h"
+#include "./fft.h"
+#include "./windows.h"
+#include "./delay.h"
+
+#include <cmath>
+
+namespace signalsmith {
+namespace spectral {
+	/**	@defgroup Spectral Spectral Processing
+		@brief Tools for frequency-domain manipulation of audio signals
+		
+		@{
+		@file
+	*/
+	
+	/** @brief An FFT with built-in windowing and round-trip scaling
+	
+		This uses a Modified Real FFT, which applies half-bin shift before the transform.  The result therefore has `N/2` bins, centred at the frequencies: `(i + 0.5)/N`.
+		
+		This avoids the awkward (real-valued) bands for DC-offset and Nyquist.
+	 */
+	template<typename Sample>
+	class WindowedFFT {
+		using MRFFT = signalsmith::fft::ModifiedRealFFT<Sample>;
+		using Complex = std::complex<Sample>;
+		MRFFT mrfft{2};
+
+		std::vector<Sample> fftWindow;
+		std::vector<Sample> timeBuffer;
+		int offsetSamples = 0;
+	public:
+		/// Returns a fast FFT size <= `size`
+		static int fastSizeAbove(int size, int divisor=1) {
+			return MRFFT::fastSizeAbove(size/divisor)*divisor;
+		}
+		/// Returns a fast FFT size >= `size`
+		static int fastSizeBelow(int size, int divisor=1) {
+			return MRFFT::fastSizeBelow(1 + (size - 1)/divisor)*divisor;
+		}
+
+		WindowedFFT() {}
+		WindowedFFT(int size, int rotateSamples=0) {
+			setSize(size, rotateSamples);
+		}
+		template<class WindowFn>
+		WindowedFFT(int size, WindowFn fn, Sample windowOffset=0.5, int rotateSamples=0) {
+			setSize(size, fn, windowOffset, rotateSamples);
+		}
+
+		/// Sets the size, returning the window for modification (initially all 1s)
+		std::vector<Sample> & setSizeWindow(int size, int rotateSamples=0) {
+			mrfft.setSize(size);
+			fftWindow.assign(size, 1);
+			timeBuffer.resize(size);
+			offsetSamples = rotateSamples;
+			if (offsetSamples < 0) offsetSamples += size; // TODO: for a negative rotation, the other half of the result is inverted
+			return fftWindow;
+		}
+		/// Sets the FFT size, with a user-defined functor for the window
+		template<class WindowFn>
+		void setSize(int size, WindowFn fn, Sample windowOffset=0.5, int rotateSamples=0) {
+			setSizeWindow(size, rotateSamples);
+		
+			Sample invSize = 1/(Sample)size;
+			for (int i = 0; i < size; ++i) {
+				Sample r = (i + windowOffset)*invSize;
+				fftWindow[i] = fn(r);
+			}
+		}
+		/// Sets the size (using the default Blackman-Harris window)
+		void setSize(int size, int rotateSamples=0) {
+			setSize(size, [](double x) {
+				double phase = 2*M_PI*x;
+				// Blackman-Harris
+				return 0.35875 - 0.48829*std::cos(phase) + 0.14128*std::cos(phase*2) - 0.01168*std::cos(phase*3);
+			}, Sample(0.5), rotateSamples);
+		}
+
+		const std::vector<Sample> & window() const {
+			return this->fftWindow;
+		}
+		int size() const {
+			return mrfft.size();
+		}
+		
+		/// Performs an FFT (with windowing)
+		template<class Input, class Output>
+		void fft(Input &&input, Output &&output) {
+			int fftSize = size();
+			for (int i = 0; i < offsetSamples; ++i) {
+				// Inverted polarity since we're using the MRFFT
+				timeBuffer[i + fftSize - offsetSamples] = -input[i]*fftWindow[i];
+			}
+			for (int i = offsetSamples; i < fftSize; ++i) {
+				timeBuffer[i - offsetSamples] = input[i]*fftWindow[i];
+			}
+			mrfft.fft(timeBuffer, output);
+		}
+		/// Performs an FFT (no windowing or rotation)
+		template<class Input, class Output>
+		void fftRaw(Input &&input, Output &&output) {
+			mrfft.fft(input, output);
+		}
+
+		/// Inverse FFT, with windowing and 1/N scaling
+		template<class Input, class Output>
+		void ifft(Input &&input, Output &&output) {
+			mrfft.ifft(input, timeBuffer);
+			int fftSize = mrfft.size();
+			Sample norm = 1/(Sample)fftSize;
+
+			for (int i = 0; i < offsetSamples; ++i) {
+				// Inverted polarity since we're using the MRFFT
+				output[i] = -timeBuffer[i + fftSize - offsetSamples]*norm*fftWindow[i];
+			}
+			for (int i = offsetSamples; i < fftSize; ++i) {
+				output[i] = timeBuffer[i - offsetSamples]*norm*fftWindow[i];
+			}
+		}
+		/// Performs an IFFT (no windowing or rotation)
+		template<class Input, class Output>
+		void ifftRaw(Input &&input, Output &&output) {
+			mrfft.ifft(input, output);
+		}
+	};
+	
+	/** STFT synthesis, built on a `MultiBuffer`.
+ 
+		Any window length and block interval is supported, but the FFT size may be rounded up to a faster size (by zero-padding).  It uses a heuristically-optimal Kaiser window modified for perfect-reconstruction.
+		
+		\diagram{stft-aliasing-simulated.svg,Simulated bad-case aliasing (random phase-shift for each band) for overlapping ratios}
+
+		There is a "latest valid index", and you can read the output up to one `historyLength` behind this (see `.resize()`).  You can read up to one window-length _ahead_ to get partially-summed future output.
+		
+		\diagram{stft-buffer-validity.svg}
+		
+		You move the valid index along using `.ensureValid()`, passing in a functor which provides spectra (using `.analyse()` and/or direct modification through `.spectrum[c]`):
+
+		\code
+			void processSample(...) {
+				stft.ensureValid([&](int) {
+					// Here, we introduce (1 - windowSize) of latency
+					stft.analyse(inputBuffer.view(1 - windowSize))
+				});
+				// read as a MultiBuffer
+				auto result = stft.at(0);
+				++stft; // also moves the latest valid index
+			}
+
+			void processBlock(...) {
+				// assuming `historyLength` == blockSize
+				stft.ensureValid(blockSize, [&](int blockStartIndex) {
+					int inputStart = blockStartIndex + (1 - windowSize);
+					stft.analyse(inputBuffer.view(inputStart));
+				});
+				auto earliestValid = stft.at(0);
+				auto latestValid = stft.at(blockSize);
+				stft += blockSize;
+			}
+		\endcode
+		
+		The index passed to this functor will be greater than the previous valid index, and `<=` the index you pass in.  Therefore, if you call `.ensureValid()` every sample, it can only ever be `0`.
+	*/
+	template<typename Sample>
+	class STFT : public signalsmith::delay::MultiBuffer<Sample> {
+		using Super = signalsmith::delay::MultiBuffer<Sample>;
+		using Complex = std::complex<Sample>;
+
+		int channels = 0, _windowSize = 0, _fftSize = 0, _interval = 1;
+		int validUntilIndex = 0;
+
+		class MultiSpectrum {
+			int channels, stride;
+			std::vector<Complex> buffer;
+		public:
+			MultiSpectrum() : MultiSpectrum(0, 0) {}
+			MultiSpectrum(int channels, int bands) : channels(channels), stride(bands), buffer(channels*bands, 0) {}
+			
+			void resize(int nChannels, int nBands) {
+				channels = nChannels;
+				stride = nBands;
+				buffer.assign(channels*stride, 0);
+			}
+			
+			void reset() {
+				buffer.assign(buffer.size(), 0);
+			}
+			
+			void swap(MultiSpectrum &other) {
+				using std::swap;
+				swap(buffer, other.buffer);
+			}
+
+			Complex * operator [](int channel) {
+				return buffer.data() + channel*stride;
+			}
+			const Complex * operator [](int channel) const {
+				return buffer.data() + channel*stride;
+			}
+		};
+		std::vector<Sample> timeBuffer;
+
+		void resizeInternal(int newChannels, int windowSize, int newInterval, int historyLength, int zeroPadding) {
+			Super::resize(newChannels,
+				windowSize /* for output summing */
+				+ newInterval /* so we can read `windowSize` ahead (we'll be at most `interval-1` from the most recent block */
+				+ historyLength);
+
+			int fftSize = fft.fastSizeAbove(windowSize + zeroPadding);
+			
+			this->channels = newChannels;
+			_windowSize = windowSize;
+			this->_fftSize = fftSize;
+			this->_interval = newInterval;
+			validUntilIndex = -1;
+			
+			setWindow(windowShape);
+
+			spectrum.resize(channels, fftSize/2);
+			timeBuffer.resize(fftSize);
+		}
+	public:
+		enum class Window {kaiser, acg};
+		/// \deprecated use `.setWindow()` which actually updates the window when you change it
+		Window windowShape = Window::kaiser;
+		// for convenience
+		static constexpr Window kaiser = Window::kaiser;
+		static constexpr Window acg = Window::acg;
+		
+		/** Swaps between the default (Kaiser) shape and Approximate Confined Gaussian (ACG).
+		\diagram{stft-windows.svg,Default (Kaiser) windows and partial cumulative sum}
+		The ACG has better rolloff since its edges go to 0:
+		\diagram{stft-windows-acg.svg,ACG windows and partial cumulative sum}
+		However, it generally has worse performance in terms of total sidelobe energy, affecting worst-case aliasing levels for (most) higher overlap ratios:
+		\diagram{stft-aliasing-simulated-acg.svg,Simulated bad-case aliasing for ACG windows - compare with above}*/
+		// TODO: these should both be set before resize()
+		void setWindow(Window shape, bool rotateToZero=false) {
+			windowShape = shape;
+
+			auto &window = fft.setSizeWindow(_fftSize, rotateToZero ? _windowSize/2 : 0);
+			if (windowShape == Window::kaiser) {
+				using Kaiser = ::signalsmith::windows::Kaiser;
+				/// Roughly optimal Kaiser for STFT analysis (forced to perfect reconstruction)
+				auto kaiser = Kaiser::withBandwidth(_windowSize/double(_interval), true);
+				kaiser.fill(window, _windowSize);
+			} else {
+				using Confined = ::signalsmith::windows::ApproximateConfinedGaussian;
+				auto confined = Confined::withBandwidth(_windowSize/double(_interval));
+				confined.fill(window, _windowSize);
+			}
+			::signalsmith::windows::forcePerfectReconstruction(window, _windowSize, _interval);
+			
+			// TODO: fill extra bits of an input buffer with NaN/Infinity, to break this, and then fix by adding zero-padding to WindowedFFT (as opposed to zero-valued window sections)
+			for (int i = _windowSize; i < _fftSize; ++i) {
+				window[i] = 0;
+			}
+		}
+		
+		using Spectrum = MultiSpectrum;
+		Spectrum spectrum;
+		WindowedFFT<Sample> fft;
+		
+		STFT() {}
+		/// Parameters passed straight to `.resize()`
+		STFT(int channels, int windowSize, int interval, int historyLength=0, int zeroPadding=0) {
+			resize(channels, windowSize, interval, historyLength, zeroPadding);
+		}
+
+		/// Sets the channel-count, FFT size and interval.
+		void resize(int nChannels, int windowSize, int interval, int historyLength=0, int zeroPadding=0) {
+			resizeInternal(nChannels, windowSize, interval, historyLength, zeroPadding);
+		}
+		
+		int windowSize() const {
+			return _windowSize;
+		}
+		int fftSize() const {
+			return _fftSize;
+		}
+		int interval() const {
+			return _interval;
+		}
+		/// Returns the (analysis and synthesis) window
+		decltype(fft.window()) window() const {
+			return fft.window();
+		}
+		/// Calculates the effective window for the partially-summed future output (relative to the most recent block)
+		std::vector<Sample> partialSumWindow(bool includeLatestBlock=true) const {
+			const auto &w = window();
+			std::vector<Sample> result(_windowSize, 0);
+			int firstOffset = (includeLatestBlock ? 0 : _interval);
+			for (int offset = firstOffset; offset < _windowSize; offset += _interval) {
+				for (int i = 0; i < _windowSize - offset; ++i) {
+					Sample value = w[i + offset];
+					result[i] += value*value;
+				}
+			}
+			return result;
+		}
+		
+		/// Resets everything - since we clear the output sum, it will take `windowSize` samples to get proper output.
+		void reset() {
+			Super::reset();
+			spectrum.reset();
+			validUntilIndex = -1;
+		}
+		
+		/** Generates valid output up to the specified index (or 0), using the callback as many times as needed.
+			
+			The callback should be a functor accepting a single integer argument, which is the index for which a spectrum is required.
+			
+			The block created from these spectra will start at this index in the output, plus `.latency()`.
+		*/
+		template<class AnalysisFn>
+		void ensureValid(int i, AnalysisFn fn) {
+			while (validUntilIndex < i) {
+				int blockIndex = validUntilIndex + 1;
+				fn(blockIndex);
+
+				auto output = this->view(blockIndex);
+				for (int c = 0; c < channels; ++c) {
+					auto channel = output[c];
+
+					// Clear out the future sum, a window-length and an interval ahead
+					for (int wi = _windowSize; wi < _windowSize + _interval; ++wi) {
+						channel[wi] = 0;
+					}
+
+					// Add in the IFFT'd result
+					fft.ifft(spectrum[c], timeBuffer);
+					for (int wi = 0; wi < _windowSize; ++wi) {
+						channel[wi] += timeBuffer[wi];
+					}
+				}
+				validUntilIndex += _interval;
+			}
+		}
+		/// The same as above, assuming index 0
+		template<class AnalysisFn>
+		void ensureValid(AnalysisFn fn) {
+			return ensureValid(0, fn);
+		}
+		/// Returns the next invalid index (a.k.a. the index of the next block)
+		int nextInvalid() const {
+			return validUntilIndex + 1;
+		}
+		
+		/** Analyse a multi-channel input, for any type where `data[channel][index]` returns samples
+ 
+		Results can be read/edited using `.spectrum`. */
+		template<class Data>
+		void analyse(Data &&data) {
+			for (int c = 0; c < channels; ++c) {
+				fft.fft(data[c], spectrum[c]);
+			}
+		}
+		template<class Data>
+		void analyse(int c, Data &&data) {
+			fft.fft(data, spectrum[c]);
+		}
+		/// Analyse without windowing or zero-rotation
+		template<class Data>
+		void analyseRaw(Data &&data) {
+			for (int c = 0; c < channels; ++c) {
+				fft.fftRaw(data[c], spectrum[c]);
+			}
+		}
+		template<class Data>
+		void analyseRaw(int c, Data &&data) {
+			fft.fftRaw(data, spectrum[c]);
+		}
+
+		int bands() const {
+			return _fftSize/2;
+		}
+
+		/** Internal latency (between the block-index requested in `.ensureValid()` and its position in the output)
+ 
+		Currently unused, but it's in here to allow for a future implementation which spreads the FFT calculations out across each interval.*/
+		int latency() {
+			return 0;
+		}
+		
+		// @name Shift the underlying buffer (moving the "valid" index accordingly)
+		// @{
+		STFT & operator ++() {
+			Super::operator ++();
+			validUntilIndex--;
+			return *this;
+		}
+		STFT & operator +=(int i) {
+			Super::operator +=(i);
+			validUntilIndex -= i;
+			return *this;
+		}
+		STFT & operator --() {
+			Super::operator --();
+			validUntilIndex++;
+			return *this;
+		}
+		STFT & operator -=(int i) {
+			Super::operator -=(i);
+			validUntilIndex += i;
+			return *this;
+		}
+		// @}
+
+		typename Super::MutableView operator ++(int postIncrement) {
+			auto result = Super::operator ++(postIncrement);
+			validUntilIndex--;
+			return result;
+		}
+		typename Super::MutableView operator --(int postIncrement) {
+			auto result = Super::operator --(postIncrement);
+			validUntilIndex++;
+			return result;
+		}
+	};
+
+	/** STFT processing, with input/output.
+		Before calling `.ensureValid(index)`, you should make sure the input is filled up to `index`.
+	*/
+	template<typename Sample>
+	class ProcessSTFT : public STFT<Sample> {
+		using Super = STFT<Sample>;
+	public:
+		signalsmith::delay::MultiBuffer<Sample> input;
+	
+		ProcessSTFT(int inChannels, int outChannels, int windowSize, int interval, int historyLength=0) {
+			resize(inChannels, outChannels, windowSize, interval, historyLength);
+		}
+
+		/** Alter the spectrum, using input up to this point, for the output block starting from this point.
+			Sub-classes should replace this with whatever processing is desired. */
+		virtual void processSpectrum(int /*blockIndex*/) {}
+		
+		/// Sets the input/output channels, FFT size and interval.
+		void resize(int inChannels, int outChannels, int windowSize, int interval, int historyLength=0) {
+			Super::resize(outChannels, windowSize, interval, historyLength);
+			input.resize(inChannels, windowSize + interval + historyLength);
+		}
+		void reset(Sample value=Sample()) {
+			Super::reset(value);
+			input.reset(value);
+		}
+
+		/// Internal latency, including buffering samples for analysis.
+		int latency() {
+			return Super::latency() + (this->windowSize() - 1);
+		}
+		
+		void ensureValid(int i=0) {
+			Super::ensureValid(i, [&](int blockIndex) {
+				this->analyse(input.view(blockIndex - this->windowSize() + 1));
+				this->processSpectrum(blockIndex);
+			});
+		}
+
+		// @name Shift the output, input, and valid index.
+		// @{
+		ProcessSTFT & operator ++() {
+			Super::operator ++();
+			++input;
+			return *this;
+		}
+		ProcessSTFT & operator +=(int i) {
+			Super::operator +=(i);
+			input += i;
+			return *this;
+		}
+		ProcessSTFT & operator --() {
+			Super::operator --();
+			--input;
+			return *this;
+		}
+		ProcessSTFT & operator -=(int i) {
+			Super::operator -=(i);
+			input -= i;
+			return *this;
+		}
+		// @}
+	};
+
+/** @} */
+}} // signalsmith::spectral::
+#endif // include guard

--- a/examples/dsp/windows.h
+++ b/examples/dsp/windows.h
@@ -1,0 +1,219 @@
+#include "./common.h"
+
+#ifndef SIGNALSMITH_DSP_WINDOWS_H
+#define SIGNALSMITH_DSP_WINDOWS_H
+
+#include <cmath>
+#include <algorithm>
+
+namespace signalsmith {
+namespace windows {
+	/**	@defgroup Windows Window functions
+		@brief Windows for spectral analysis
+		
+		These are generally double-precision, because they are mostly calculated during setup/reconfiguring, not real-time code.
+		
+		@{
+		@file
+	*/
+	
+	/** @brief The Kaiser window (almost) maximises the energy in the main-lobe compared to the side-lobes.
+		
+		Kaiser windows can be constructing using the shape-parameter (beta) or using the static `with???()` methods.*/
+	class Kaiser {
+		// I_0(x)=\sum_{k=0}^{N}\frac{x^{2k}}{(k!)^2\cdot4^k}
+		inline static double bessel0(double x) {
+			const double significanceLimit = 1e-4;
+			double result = 0;
+			double term = 1;
+			double m = 0;
+			while (term > significanceLimit) {
+				result += term;
+				++m;
+				term *= (x*x)/(4*m*m);
+			}
+
+			return result;
+		}
+		double beta;
+		double invB0;
+		
+		static double heuristicBandwidth(double bandwidth) {
+			// Good peaks
+			//return bandwidth + 8/((bandwidth + 3)*(bandwidth + 3));
+			// Good average
+			//return bandwidth + 14/((bandwidth + 2.5)*(bandwidth + 2.5));
+			// Compromise
+			return bandwidth + 8/((bandwidth + 3)*(bandwidth + 3)) + 0.25*std::max(3 - bandwidth, 0.0);
+		}
+	public:
+		/// Set up a Kaiser window with a given shape.  `beta` is `pi*alpha` (since there is ambiguity about shape parameters)
+		Kaiser(double beta) : beta(beta), invB0(1/bessel0(beta)) {}
+
+		/// @name Bandwidth methods
+		/// @{
+		static Kaiser withBandwidth(double bandwidth, bool heuristicOptimal=false) {
+			return Kaiser(bandwidthToBeta(bandwidth, heuristicOptimal));
+		}
+
+		/** Returns the Kaiser shape where the main lobe has the specified bandwidth (as a factor of 1/window-length).
+		\diagram{kaiser-windows.svg,You can see that the main lobe matches the specified bandwidth.}
+		If `heuristicOptimal` is enabled, the main lobe width is _slightly_ wider, improving both the peak and total energy - see `bandwidthToEnergyDb()` and `bandwidthToPeakDb()`.
+		\diagram{kaiser-windows-heuristic.svg, The main lobe extends to ±bandwidth/2.} */
+		static double bandwidthToBeta(double bandwidth, bool heuristicOptimal=false) {
+			if (heuristicOptimal) { // Heuristic based on numerical search
+				bandwidth = heuristicBandwidth(bandwidth);
+			}
+			bandwidth = std::max(bandwidth, 2.0);
+			double alpha = std::sqrt(bandwidth*bandwidth*0.25 - 1);
+			return alpha*M_PI;
+		}
+		
+		static double betaToBandwidth(double beta) {
+			double alpha = beta*(1.0/M_PI);
+			return 2*std::sqrt(alpha*alpha + 1);
+		}
+		/// @}
+
+		/// @name Performance methods
+		/// @{
+		/** @brief Total energy ratio (in dB) between side-lobes and the main lobe.
+			\diagram{windows-kaiser-sidelobe-energy.svg,Measured main/side lobe energy ratio.  You can see that the heuristic improves performance for all bandwidth values.}
+			This function uses an approximation which is accurate to ±0.5dB for 2 ⩽ bandwidth ≤ 10, or 1 ⩽ bandwidth ≤ 10 when `heuristicOptimal`is enabled.
+		*/
+		static double bandwidthToEnergyDb(double bandwidth, bool heuristicOptimal=false) {
+			// Horrible heuristic fits
+			if (heuristicOptimal) {
+				if (bandwidth < 3) bandwidth += (3 - bandwidth)*0.5;
+				return 12.9 + -3/(bandwidth + 0.4) - 13.4*bandwidth + (bandwidth < 3)*-9.6*(bandwidth - 3);
+			}
+			return 10.5 + 15/(bandwidth + 0.4) - 13.25*bandwidth + (bandwidth < 2)*13*(bandwidth - 2);
+		}
+		static double energyDbToBandwidth(double energyDb, bool heuristicOptimal=false) {
+			double bw = 1;
+			while (bw < 20 && bandwidthToEnergyDb(bw, heuristicOptimal) > energyDb) {
+				bw *= 2;
+			}
+			double step = bw/2;
+			while (step > 0.0001) {
+				if (bandwidthToEnergyDb(bw, heuristicOptimal) > energyDb) {
+					bw += step;
+				} else {
+					bw -= step;
+				}
+				step *= 0.5;
+			}
+			return bw;
+		}
+		/** @brief Peak ratio (in dB) between side-lobes and the main lobe.
+			\diagram{windows-kaiser-sidelobe-peaks.svg,Measured main/side lobe peak ratio.  You can see that the heuristic improves performance, except in the bandwidth range 1-2 where peak ratio was sacrificed to improve total energy ratio.}
+			This function uses an approximation which is accurate to ±0.5dB for 2 ⩽ bandwidth ≤ 9, or 0.5 ⩽ bandwidth ≤ 9 when `heuristicOptimal`is enabled.
+		*/
+		static double bandwidthToPeakDb(double bandwidth, bool heuristicOptimal=false) {
+			// Horrible heuristic fits
+			if (heuristicOptimal) {
+				return 14.2 - 20/(bandwidth + 1) - 13*bandwidth + (bandwidth < 3)*-6*(bandwidth - 3) + (bandwidth < 2.25)*5.8*(bandwidth - 2.25);
+			}
+			return 10 + 8/(bandwidth + 2) - 12.75*bandwidth + (bandwidth < 2)*4*(bandwidth - 2);
+		}
+		static double peakDbToBandwidth(double peakDb, bool heuristicOptimal=false) {
+			double bw = 1;
+			while (bw < 20 && bandwidthToPeakDb(bw, heuristicOptimal) > peakDb) {
+				bw *= 2;
+			}
+			double step = bw/2;
+			while (step > 0.0001) {
+				if (bandwidthToPeakDb(bw, heuristicOptimal) > peakDb) {
+					bw += step;
+				} else {
+					bw -= step;
+				}
+				step *= 0.5;
+			}
+			return bw;
+		}
+		/** @} */
+
+		/** Equivalent noise bandwidth (ENBW), a measure of frequency resolution.
+			\diagram{windows-kaiser-enbw.svg,Measured ENBW\, with and without the heuristic bandwidth adjustment.}
+			This approximation is accurate to ±0.05 up to a bandwidth of 22.
+		*/
+		static double bandwidthToEnbw(double bandwidth, bool heuristicOptimal=false) {
+			if (heuristicOptimal) bandwidth = heuristicBandwidth(bandwidth);
+			double b2 = std::max<double>(bandwidth - 2, 0);
+			return 1 + b2*(0.2 + b2*(-0.005 + b2*(-0.000005 + b2*0.0000022)));
+		}
+
+		/// Return the window's value for position in the range [0, 1]
+		double operator ()(double unit) {
+			double r = 2*unit - 1;
+			double arg = std::sqrt(1 - r*r);
+			return bessel0(beta*arg)*invB0;
+		}
+	
+		/// Fills an arbitrary container with a Kaiser window
+		template<typename Data>
+		void fill(Data &&data, int size) const {
+			double invSize = 1.0/size;
+			for (int i = 0; i < size; ++i) {
+				double r = (2*i + 1)*invSize - 1;
+				double arg = std::sqrt(1 - r*r);
+				data[i] = bessel0(beta*arg)*invB0;
+			}
+		}
+	};
+
+	/** @brief The Approximate Confined Gaussian window is (almost) optimal
+		
+		ACG windows can be constructing using the shape-parameter (sigma) or using the static `with???()` methods.*/
+	class ApproximateConfinedGaussian {
+		double gaussianFactor;
+		
+		double gaussian(double x) const {
+			return std::exp(-x*x*gaussianFactor);
+		}
+	public:
+		/// Heuristic map from bandwidth to the appropriately-optimal sigma
+		static double bandwidthToSigma(double bandwidth) {
+			return 0.3/std::sqrt(bandwidth);
+		}
+		static ApproximateConfinedGaussian withBandwidth(double bandwidth) {
+			return ApproximateConfinedGaussian(bandwidthToSigma(bandwidth));
+		}
+
+		ApproximateConfinedGaussian(double sigma) : gaussianFactor(0.0625/(sigma*sigma)) {}
+	
+		/// Fills an arbitrary container
+		template<typename Data>
+		void fill(Data &&data, int size) const {
+			double invSize = 1.0/size;
+			double offsetScale = gaussian(1)/(gaussian(3) + gaussian(-1));
+			double norm = 1/(gaussian(0) - 2*offsetScale*(gaussian(2)));
+			for (int i = 0; i < size; ++i) {
+				double r = (2*i + 1)*invSize - 1;
+				data[i] = norm*(gaussian(r) - offsetScale*(gaussian(r - 2) + gaussian(r + 2)));
+			}
+		}
+	};
+
+	/** Forces STFT perfect-reconstruction (WOLA) on an existing window, for a given STFT interval.
+	For example, here are perfect-reconstruction versions of the approximately-optimal @ref Kaiser windows:
+	\diagram{kaiser-windows-heuristic-pr.svg,Note the lower overall energy\, and the pointy top for 2x bandwidth. Spectral performance is about the same\, though.}
+	*/
+	template<typename Data>
+	void forcePerfectReconstruction(Data &&data, int windowLength, int interval) {
+		for (int i = 0; i < interval; ++i) {
+			double sum2 = 0;
+			for (int index = i; index < windowLength; index += interval) {
+				sum2 += data[index]*data[index];
+			}
+			double factor = 1/std::sqrt(sum2);
+			for (int index = i; index < windowLength; index += interval) {
+				data[index] *= factor;
+			}
+		}
+	}
+
+/** @} */
+}} // signalsmith::windows
+#endif // include guard

--- a/examples/equalizer/equalizer.cpp
+++ b/examples/equalizer/equalizer.cpp
@@ -1,0 +1,138 @@
+/*
+ * AIDA-X Equalizer plugin for Chaos Audio
+ * Copyright (C) 2024 Massimo Pennazio <maxipenna@libero.it>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "dsp.hpp"
+
+#include <Eq5Bands.hpp>
+
+class Equalizer : public dsp {
+private:
+    Eq5Bands* eq5Bands;
+
+public:
+    float knobs_old[MAXKNOBS];
+    SWITCH_STATE switches_old[MAXSWITCHES];
+
+    Equalizer() {
+        // Initialize your plugin here
+        eq5Bands = nullptr;
+    }
+
+    ~Equalizer() {
+        // Clean up your plugin here
+        if (eq5Bands != nullptr)
+            delete eq5Bands;
+    }
+
+    virtual void instanceConstants() override {
+        // Implement the pure virtual function from the base class here
+        // Set the constants for your plugin here
+        version = "0.9.0";
+        name = "Equalizer";
+        if (eq5Bands != nullptr) {
+            delete eq5Bands;
+        }
+        eq5Bands = new Eq5Bands(getSampleRate());
+        // Initialize controls, mapping to the correct values
+        knobs[0] = MAP(eq5Bands->bass_boost_db, -8.0f, 8.0f, 0.0f, 10.0f);
+        knobs[1] = MAP(eq5Bands->mid_boost_db, -8.0f, 8.0f, 0.0f, 10.0f);
+        knobs[2] = MAP(eq5Bands->treble_boost_db, -8.0f, 8.0f, 0.0f, 10.0f);
+        knobs[3] = MAP(eq5Bands->depth_boost_db, -8.0f, 8.0f, 0.0f, 10.0f);
+        knobs[4] = MAP(eq5Bands->presence_boost_db, -8.0f, 8.0f, 0.0f, 10.0f);
+        knobs[5] = MAP(eq5Bands->mid_freq, 150.0f, 5000.0f, 0.0f, 10.0f);
+        switches[1] = eq5Bands->mid_type == 0 ? DOWN : UP;
+        knobs_old[0] = knobs[0];
+        knobs_old[1] = knobs[1];
+        knobs_old[2] = knobs[2];
+        knobs_old[3] = knobs[3];
+        knobs_old[4] = knobs[4];
+        knobs_old[5] = knobs[5];
+        switches_old[1] = switches[1];
+    }
+
+    virtual void compute(int count, FAUSTFLOAT* input0, FAUSTFLOAT* output0) override {
+        // Implement the compute method here
+        uint8_t bass_has_changed = 0;
+        uint8_t mid_has_changed = 0;
+        uint8_t treble_has_changed = 0;
+        uint8_t depth_has_changed = 0;
+        uint8_t presence_has_changed = 0;
+
+        if (eq5Bands == nullptr) {
+            return;
+        } else {
+            /* Bass */
+            if (knobs[0] != knobs_old[0]) {
+                knobs_old[0] = knobs[0];
+                eq5Bands->bass_boost_db = MAP(knobs_old[0], 0.0f, 10.0f, -8.0f, 8.0f);
+                bass_has_changed++;
+            }
+            if (bass_has_changed) {
+                eq5Bands->updateBass();
+            }
+            /* Mid */
+            if (knobs[1] != knobs_old[1]) {
+                knobs_old[1] = knobs[1];
+                eq5Bands->mid_boost_db = MAP(knobs_old[1], 0.0f, 10.0f, -8.0f, 8.0f);
+                mid_has_changed++;
+            }
+            if (knobs[5] != knobs_old[5]) {
+                knobs_old[5] = knobs[5];
+                eq5Bands->mid_freq = MAP(knobs_old[5], 0.0f, 10.0f, 150.0f, 5000.0f);
+                mid_has_changed++;
+            }
+            if (switches[1] != switches_old[1]) {
+                switches_old[1] = switches[1];
+                eq5Bands->mid_type = switches_old[1] == DOWN ? 0 : 1;
+                mid_has_changed++;
+            }
+            if (mid_has_changed) {
+                eq5Bands->updateMid();
+            }
+            /* Treble */
+            if (knobs[2] != knobs_old[2]) {
+                knobs_old[2] = knobs[2];
+                eq5Bands->treble_boost_db = MAP(knobs_old[2], 0.0f, 10.0f, -8.0f, 8.0f);
+                treble_has_changed++;
+            }
+            if (treble_has_changed) {
+                eq5Bands->updateTreble();
+            }
+            /* Depth */
+            if (knobs[3] != knobs_old[3]) {
+                knobs_old[3] = knobs[3];
+                eq5Bands->depth_boost_db = MAP(knobs_old[3], 0.0f, 10.0f, -8.0f, 8.0f);
+                depth_has_changed++;
+            }
+            if (depth_has_changed) {
+                eq5Bands->updateDepth();
+            }
+            /* Presence */
+            if (knobs[4] != knobs_old[4]) {
+                knobs_old[4] = knobs[4];
+                eq5Bands->presence_boost_db = MAP(knobs_old[4], 0.0f, 10.0f, -8.0f, 8.0f);
+                presence_has_changed++;
+            }
+            if (presence_has_changed) {
+                eq5Bands->updatePresence();
+            }
+            /* Apply filters */
+            eq5Bands->process(count, input0, output0);
+        }
+    }
+
+    // If you need to override any other methods from the base class, you can do so here
+};
+
+extern "C" dsp* create() {
+    return new Equalizer();
+}
+
+extern "C" void destroy(dsp* p) {
+    delete p;
+}
+
+extern "C" const char* dsp_version = DSP_VERSION;

--- a/examples/pitchshifter.cpp
+++ b/examples/pitchshifter.cpp
@@ -1,0 +1,61 @@
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include "dsp.hpp"
+#include "signalsmith-stretch.h"
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class pitchshifter : public dsp {
+
+ private:
+	
+    int sampleRate = 44100;
+    signalsmith::stretch::SignalsmithStretch<float> stretch;
+    int channels = 1;
+    float* inputBuffers[1];
+    float* outputBuffers[1];
+	
+ public:
+		
+ void instanceConstants() {
+        stretch.presetDefault(channels, sampleRate);
+        stretch.setTransposeSemitones(12, 8000/sampleRate);
+		version = "0.1.1";
+	}
+
+	void instanceClear() {
+
+	}
+	
+	void compute(int count, FAUSTFLOAT* input0, FAUSTFLOAT* output0) {
+        
+        inputBuffers[0] = input0;
+        outputBuffers[0] = output0;
+        
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+            stretch.process(inputBuffers, count, outputBuffers, count);
+		}
+        stretch.reset();
+        
+	}
+
+};
+	extern "C" {
+	dsp * create() {
+		return new pitchshifter;
+	}
+}
+
+#endif

--- a/examples/signalsmith-stretch.h
+++ b/examples/signalsmith-stretch.h
@@ -1,0 +1,633 @@
+#ifndef SIGNALSMITH_STRETCH_H
+#define SIGNALSMITH_STRETCH_H
+
+#include "dsp/spectral.h"
+#include "dsp/delay.h"
+#include "dsp/perf.h"
+SIGNALSMITH_DSP_VERSION_CHECK(1, 6, 0); // Check version is compatible
+#include <vector>
+#include <algorithm>
+#include <functional>
+#include <random>
+
+namespace signalsmith { namespace stretch {
+
+template<typename Sample=float>
+struct SignalsmithStretch {
+
+	SignalsmithStretch() : randomEngine(std::random_device{}()) {}
+	SignalsmithStretch(long seed) : randomEngine(seed) {}
+
+	int blockSamples() const {
+		return stft.windowSize();
+	}
+	int intervalSamples() const {
+		return stft.interval();
+	}
+	int inputLatency() const {
+		return stft.windowSize()/2;
+	}
+	int outputLatency() const {
+		return stft.windowSize() - inputLatency();
+	}
+	
+	void reset() {
+		stft.reset();
+		inputBuffer.reset();
+		prevInputOffset = -1;
+		channelBands.assign(channelBands.size(), Band());
+		silenceCounter = 2*stft.windowSize();
+		didSeek = false;
+		flushed = true;
+	}
+
+	// Configures using a default preset
+	void presetDefault(int nChannels, Sample sampleRate) {
+		configure(nChannels, sampleRate*0.12, sampleRate*0.03);
+	}
+	void presetCheaper(int nChannels, Sample sampleRate) {
+		configure(nChannels, sampleRate*0.1, sampleRate*0.04);
+	}
+
+	// Manual setup
+	void configure(int nChannels, int blockSamples, int intervalSamples) {
+		channels = nChannels;
+		stft.resize(channels, blockSamples, intervalSamples);
+		bands = stft.bands();
+		inputBuffer.resize(channels, blockSamples + intervalSamples + 1);
+		timeBuffer.assign(stft.fftSize(), 0);
+		channelBands.assign(bands*channels, Band());
+		
+		// Various phase rotations
+		rotCentreSpectrum.resize(bands);
+		rotPrevInterval.assign(bands, 0);
+		timeShiftPhases(blockSamples*Sample(-0.5), rotCentreSpectrum);
+		timeShiftPhases(-intervalSamples, rotPrevInterval);
+		peaks.reserve(bands);
+		energy.resize(bands);
+		smoothedEnergy.resize(bands);
+		outputMap.resize(bands);
+		channelPredictions.resize(channels*bands);
+	}
+
+	/// Frequency multiplier, and optional tonality limit (as multiple of sample-rate)
+	void setTransposeFactor(Sample multiplier, Sample tonalityLimit=0) {
+		freqMultiplier = multiplier;
+		if (tonalityLimit > 0) {
+			freqTonalityLimit = tonalityLimit/std::sqrt(multiplier); // compromise between input and output limits
+		} else {
+			freqTonalityLimit = 1;
+		}
+		customFreqMap = nullptr;
+	}
+	void setTransposeSemitones(Sample semitones, Sample tonalityLimit=0) {
+		setTransposeFactor(std::pow(2, semitones/12), tonalityLimit);
+		customFreqMap = nullptr;
+	}
+	// Sets a custom frequency map - should be monotonically increasing
+	void setFreqMap(std::function<Sample(Sample)> inputToOutput) {
+		customFreqMap = inputToOutput;
+	}
+
+	// Provide previous input ("pre-roll"), without affecting the speed calculation.  You should ideally feed it one block-length + one interval
+	template<class Inputs>
+	void seek(Inputs &&inputs, int inputSamples, double playbackRate) {
+		inputBuffer.reset();
+		for (int c = 0; c < channels; ++c) {
+			auto &&inputChannel = inputs[c];
+			auto &&bufferChannel = inputBuffer[c];
+			int startIndex = std::max<int>(0, inputSamples - stft.windowSize() - stft.interval());
+			for (int i = startIndex; i < inputSamples; ++i) {
+				bufferChannel[i] = inputChannel[i];
+			}
+		}
+		inputBuffer += inputSamples;
+		didSeek = true;
+		seekTimeFactor = (playbackRate*stft.interval() > 1) ? 1/playbackRate : stft.interval();
+	}
+
+	template<class Inputs, class Outputs>
+	void process(Inputs &&inputs, int inputSamples, Outputs &&outputs, int outputSamples) {
+		Sample totalEnergy = 0;
+		for (int c = 0; c < channels; ++c) {
+			auto &&inputChannel = inputs[c];
+			for (int i = 0; i < inputSamples; ++i) {
+				Sample s = inputChannel[i];
+				totalEnergy += s*s;
+			}
+		}
+		if (totalEnergy < noiseFloor) {
+			if (silenceCounter >= 2*stft.windowSize()) {
+				if (silenceFirst) {
+					silenceFirst = false;
+					for (auto &b : channelBands) {
+						b.input = b.prevInput = b.output = b.prevOutput = 0;
+						b.inputEnergy = 0;
+					}
+				}
+			
+				if (inputSamples > 0) {
+					// copy from the input, wrapping around if needed
+					for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+						int inputIndex = outputIndex%inputSamples;
+						for (int c = 0; c < channels; ++c) {
+							outputs[c][outputIndex] = inputs[c][inputIndex];
+						}
+					}
+				} else {
+					for (int c = 0; c < channels; ++c) {
+						auto &&outputChannel = outputs[c];
+						for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+							outputChannel[outputIndex] = 0;
+						}
+					}
+				}
+
+				// Store input in history buffer
+				for (int c = 0; c < channels; ++c) {
+					auto &&inputChannel = inputs[c];
+					auto &&bufferChannel = inputBuffer[c];
+					int startIndex = std::max<int>(0, inputSamples - stft.windowSize() - stft.interval());
+					for (int i = startIndex; i < inputSamples; ++i) {
+						bufferChannel[i] = inputChannel[i];
+					}
+				}
+				inputBuffer += inputSamples;
+				return;
+			} else {
+				silenceCounter += inputSamples;
+			}
+		} else {
+			silenceCounter = 0;
+			silenceFirst = true;
+		}
+
+		for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+			stft.ensureValid(outputIndex, [&](int outputOffset) {
+				// Time to process a spectrum!  Where should it come from in the input?
+				int inputOffset = std::round(outputOffset*Sample(inputSamples)/outputSamples) - stft.windowSize();
+				int inputInterval = inputOffset - prevInputOffset;
+				prevInputOffset = inputOffset;
+
+				bool newSpectrum = didSeek || (inputInterval > 0);
+				if (newSpectrum) {
+					for (int c = 0; c < channels; ++c) {
+						// Copy from the history buffer, if needed
+						auto &&bufferChannel = inputBuffer[c];
+						for (int i = 0; i < -inputOffset; ++i) {
+							timeBuffer[i] = bufferChannel[i + inputOffset];
+						}
+						// Copy the rest from the input
+						auto &&inputChannel = inputs[c];
+						for (int i = std::max<int>(0, -inputOffset); i < stft.windowSize(); ++i) {
+							timeBuffer[i] = inputChannel[i + inputOffset];
+						}
+						stft.analyse(c, timeBuffer);
+					}
+					flushed = false; // TODO: first block after a flush should be gain-compensated
+
+					for (int c = 0; c < channels; ++c) {
+						auto channelBands = bandsForChannel(c);
+						auto &&spectrumBands = stft.spectrum[c];
+						for (int b = 0; b < bands; ++b) {
+							channelBands[b].input = signalsmith::perf::mul(spectrumBands[b], rotCentreSpectrum[b]);
+						}
+					}
+
+					if (didSeek || inputInterval != stft.interval()) { // make sure the previous input is the correct distance in the past
+						int prevIntervalOffset = inputOffset - stft.interval();
+						for (int c = 0; c < channels; ++c) {
+							// Copy from the history buffer, if needed
+							auto &&bufferChannel = inputBuffer[c];
+							for (int i = 0; i < std::min(-prevIntervalOffset, stft.windowSize()); ++i) {
+								timeBuffer[i] = bufferChannel[i + prevIntervalOffset];
+							}
+							// Copy the rest from the input
+							auto &&inputChannel = inputs[c];
+							for (int i = std::max<int>(0, -prevIntervalOffset); i < stft.windowSize(); ++i) {
+								timeBuffer[i] = inputChannel[i + prevIntervalOffset];
+							}
+							stft.analyse(c, timeBuffer);
+						}
+						for (int c = 0; c < channels; ++c) {
+							auto channelBands = bandsForChannel(c);
+							auto &&spectrumBands = stft.spectrum[c];
+							for (int b = 0; b < bands; ++b) {
+								channelBands[b].prevInput = signalsmith::perf::mul(spectrumBands[b], rotCentreSpectrum[b]);
+							}
+						}
+					}
+				}
+				
+				Sample timeFactor = didSeek ? seekTimeFactor : stft.interval()/std::max<Sample>(1, inputInterval);
+				processSpectrum(newSpectrum, timeFactor);
+				didSeek = false;
+
+				for (int c = 0; c < channels; ++c) {
+					auto channelBands = bandsForChannel(c);
+					auto &&spectrumBands = stft.spectrum[c];
+					for (int b = 0; b < bands; ++b) {
+						spectrumBands[b] = signalsmith::perf::mul<true>(channelBands[b].output, rotCentreSpectrum[b]);
+					}
+				}
+			});
+
+			for (int c = 0; c < channels; ++c) {
+				auto &&outputChannel = outputs[c];
+				auto &&stftChannel = stft[c];
+				outputChannel[outputIndex] = stftChannel[outputIndex];
+			}
+		}
+
+		// Store input in history buffer
+		for (int c = 0; c < channels; ++c) {
+			auto &&inputChannel = inputs[c];
+			auto &&bufferChannel = inputBuffer[c];
+			int startIndex = std::max<int>(0, inputSamples - stft.windowSize());
+			for (int i = startIndex; i < inputSamples; ++i) {
+				bufferChannel[i] = inputChannel[i];
+			}
+		}
+		inputBuffer += inputSamples;
+		stft += outputSamples;
+		prevInputOffset -= inputSamples;
+	}
+
+	// Read the remaining output, providing no further input.  `outputSamples` should ideally be at least `.outputLatency()`
+	template<class Outputs>
+	void flush(Outputs &&outputs, int outputSamples) {
+		int plainOutput = std::min<int>(outputSamples, stft.windowSize());
+		int foldedBackOutput = std::min<int>(outputSamples, stft.windowSize() - plainOutput);
+		for (int c = 0; c < channels; ++c) {
+			auto &&outputChannel = outputs[c];
+			auto &&stftChannel = stft[c];
+			for (int i = 0; i < plainOutput; ++i) {
+				// TODO: plain output should be gain-
+				outputChannel[i] = stftChannel[i];
+			}
+			for (int i = 0; i < foldedBackOutput; ++i) {
+				outputChannel[outputSamples - 1 - i] -= stftChannel[plainOutput + i];
+			}
+			for (int i = 0; i < plainOutput + foldedBackOutput; ++i) {
+				stftChannel[i] = 0;
+			}
+		}
+		// Skip the output we just used/cleared
+		stft += plainOutput + foldedBackOutput;
+		// Reset the phase-vocoder stuff, so the next block gets a fresh start
+		for (int c = 0; c < channels; ++c) {
+			auto channelBands = bandsForChannel(c);
+			for (int b = 0; b < bands; ++b) {
+				channelBands[b].prevInput = channelBands[b].prevOutput = 0;
+			}
+		}
+		flushed = true;
+	}
+private:
+	using Complex = std::complex<Sample>;
+	static constexpr Sample noiseFloor{1e-15};
+	static constexpr Sample maxCleanStretch{2}; // time-stretch ratio before we start randomising phases
+	int silenceCounter = 0;
+	bool silenceFirst = true;
+
+	Sample freqMultiplier = 1, freqTonalityLimit = 0.5;
+	std::function<Sample(Sample)> customFreqMap = nullptr;
+
+	signalsmith::spectral::STFT<Sample> stft{0, 1, 1};
+	signalsmith::delay::MultiBuffer<Sample> inputBuffer;
+	int channels = 0, bands = 0;
+	int prevInputOffset = -1;
+	std::vector<Sample> timeBuffer;
+	bool didSeek = false, flushed = true;
+	Sample seekTimeFactor = 1;
+
+	std::vector<Complex> rotCentreSpectrum, rotPrevInterval;
+	Sample bandToFreq(Sample b) const {
+		return (b + Sample(0.5))/stft.fftSize();
+	}
+	Sample freqToBand(Sample f) const {
+		return f*stft.fftSize() - Sample(0.5);
+	}
+	void timeShiftPhases(Sample shiftSamples, std::vector<Complex> &output) const {
+		for (int b = 0; b < bands; ++b) {
+			Sample phase = bandToFreq(b)*shiftSamples*Sample(-2*M_PI);
+			output[b] = {std::cos(phase), std::sin(phase)};
+		}
+	}
+	
+	struct Band {
+		Complex input, prevInput{0};
+		Complex output, prevOutput{0};
+		Sample inputEnergy;
+	};
+	std::vector<Band> channelBands;
+	Band * bandsForChannel(int channel) {
+		return channelBands.data() + channel*bands;
+	}
+	template<Complex Band::*member>
+	Complex getBand(int channel, int index) {
+		if (index < 0 || index >= bands) return 0;
+		return channelBands[index + channel*bands].*member;
+	}
+	template<Complex Band::*member>
+	Complex getFractional(int channel, int lowIndex, Sample fractional) {
+		Complex low = getBand<member>(channel, lowIndex);
+		Complex high = getBand<member>(channel, lowIndex + 1);
+		return low + (high - low)*fractional;
+	}
+	template<Complex Band::*member>
+	Complex getFractional(int channel, Sample inputIndex) {
+		int lowIndex = std::floor(inputIndex);
+		Sample fracIndex = inputIndex - lowIndex;
+		return getFractional<member>(channel, lowIndex, fracIndex);
+	}
+	template<Sample Band::*member>
+	Sample getBand(int channel, int index) {
+		if (index < 0 || index >= bands) return 0;
+		return channelBands[index + channel*bands].*member;
+	}
+	template<Sample Band::*member>
+	Sample getFractional(int channel, int lowIndex, Sample fractional) {
+		Sample low = getBand<member>(channel, lowIndex);
+		Sample high = getBand<member>(channel, lowIndex + 1);
+		return low + (high - low)*fractional;
+	}
+	template<Sample Band::*member>
+	Sample getFractional(int channel, Sample inputIndex) {
+		int lowIndex = std::floor(inputIndex);
+		Sample fracIndex = inputIndex - lowIndex;
+		return getFractional<member>(channel, lowIndex, fracIndex);
+	}
+
+	struct Peak {
+		Sample input, output;
+	};
+	std::vector<Peak> peaks;
+	std::vector<Sample> energy, smoothedEnergy;
+	struct PitchMapPoint {
+		Sample inputBin, freqGrad;
+	};
+	std::vector<PitchMapPoint> outputMap;
+	
+	struct Prediction {
+		Sample energy = 0;
+		Complex input;
+		Complex shortVerticalTwist, longVerticalTwist;
+
+		Complex makeOutput(Complex phase) {
+			Sample phaseNorm = std::norm(phase);
+			if (phaseNorm <= noiseFloor) {
+				phase = input; // prediction is too weak, fall back to the input
+				phaseNorm = std::norm(input) + noiseFloor;
+			}
+			return phase*std::sqrt(energy/phaseNorm);
+		}
+	};
+	std::vector<Prediction> channelPredictions;
+	Prediction * predictionsForChannel(int c) {
+		return channelPredictions.data() + c*bands;
+	}
+	
+	std::default_random_engine randomEngine;
+
+	void processSpectrum(bool newSpectrum, Sample timeFactor) {
+		timeFactor = std::max<Sample>(timeFactor, 1/maxCleanStretch);
+		bool randomTimeFactor = (timeFactor > maxCleanStretch);
+		std::uniform_real_distribution<Sample> timeFactorDist(maxCleanStretch*2*randomTimeFactor - timeFactor, timeFactor);
+		
+		if (newSpectrum) {
+			for (int c = 0; c < channels; ++c) {
+				auto bins = bandsForChannel(c);
+				for (int b = 0; b < bands; ++b) {
+					auto &bin = bins[b];
+					bin.prevOutput = signalsmith::perf::mul(bin.prevOutput, rotPrevInterval[b]);
+					bin.prevInput = signalsmith::perf::mul(bin.prevInput, rotPrevInterval[b]);
+				}
+			}
+		}
+
+		Sample smoothingBins = Sample(stft.fftSize())/stft.interval();
+		int longVerticalStep = std::round(smoothingBins);
+		if (customFreqMap || freqMultiplier != 1) {
+			findPeaks(smoothingBins);
+			updateOutputMap();
+		} else { // we're not pitch-shifting, so no need to find peaks etc.
+			for (int c = 0; c < channels; ++c) {
+				Band *bins = bandsForChannel(c);
+				for (int b = 0; b < bands; ++b) {
+					bins[b].inputEnergy = std::norm(bins[b].input);
+				}
+			}
+			for (int b = 0; b < bands; ++b) {
+				outputMap[b] = {Sample(b), 1};
+			}
+		}
+
+		// Preliminary output prediction from phase-vocoder
+		for (int c = 0; c < channels; ++c) {
+			Band *bins = bandsForChannel(c);
+			auto *predictions = predictionsForChannel(c);
+			for (int b = 0; b < bands; ++b) {
+				auto mapPoint = outputMap[b];
+				int lowIndex = std::floor(mapPoint.inputBin);
+				Sample fracIndex = mapPoint.inputBin - lowIndex;
+
+				Prediction &prediction = predictions[b];
+				Sample prevEnergy = prediction.energy;
+				prediction.energy = getFractional<&Band::inputEnergy>(c, lowIndex, fracIndex);
+				prediction.energy *= std::max<Sample>(0, mapPoint.freqGrad); // scale the energy according to local stretch factor
+				prediction.input = getFractional<&Band::input>(c, lowIndex, fracIndex);
+
+				auto &outputBin = bins[b];
+				Complex prevInput = getFractional<&Band::prevInput>(c, lowIndex, fracIndex);
+				Complex freqTwist = signalsmith::perf::mul<true>(prediction.input, prevInput);
+				Complex phase = signalsmith::perf::mul(outputBin.prevOutput, freqTwist);
+				outputBin.output = phase/(std::max(prevEnergy, prediction.energy) + noiseFloor);
+
+				if (b > 0) {
+					Sample binTimeFactor = randomTimeFactor ? timeFactorDist(randomEngine) : timeFactor;
+					Complex downInput = getFractional<&Band::input>(c, mapPoint.inputBin - binTimeFactor);
+					prediction.shortVerticalTwist = signalsmith::perf::mul<true>(prediction.input, downInput);
+					if (b >= longVerticalStep) {
+						Complex longDownInput = getFractional<&Band::input>(c, mapPoint.inputBin - longVerticalStep*binTimeFactor);
+						prediction.longVerticalTwist = signalsmith::perf::mul<true>(prediction.input, longDownInput);
+					} else {
+						prediction.longVerticalTwist = 0;
+					}
+				} else {
+					prediction.shortVerticalTwist = prediction.longVerticalTwist = 0;
+				}
+			}
+		}
+
+		// Re-predict using phase differences between frequencies
+		for (int b = 0; b < bands; ++b) {
+			// Find maximum-energy channel and calculate that
+			int maxChannel = 0;
+			Sample maxEnergy = predictionsForChannel(0)[b].energy;
+			for (int c = 1; c < channels; ++c) {
+				Sample e = predictionsForChannel(c)[b].energy;
+				if (e > maxEnergy) {
+					maxChannel = c;
+					maxEnergy = e;
+				}
+			}
+
+			auto *predictions = predictionsForChannel(maxChannel);
+			auto &prediction = predictions[b];
+			auto *bins = bandsForChannel(maxChannel);
+			auto &outputBin = bins[b];
+
+			Complex phase = 0;
+
+			// Upwards vertical steps
+			if (b > 0) {
+				auto &downBin = bins[b - 1];
+				phase += signalsmith::perf::mul(downBin.output, prediction.shortVerticalTwist);
+				
+				if (b >= longVerticalStep) {
+					auto &longDownBin = bins[b - longVerticalStep];
+					phase += signalsmith::perf::mul(longDownBin.output, prediction.longVerticalTwist);
+				}
+			}
+			// Downwards vertical steps
+			if (b < bands - 1) {
+				auto &upPrediction = predictions[b + 1];
+				auto &upBin = bins[b + 1];
+				phase += signalsmith::perf::mul<true>(upBin.output, upPrediction.shortVerticalTwist);
+				
+				if (b < bands - longVerticalStep) {
+					auto &longUpPrediction = predictions[b + longVerticalStep];
+					auto &longUpBin = bins[b + longVerticalStep];
+					phase += signalsmith::perf::mul<true>(longUpBin.output, longUpPrediction.longVerticalTwist);
+				}
+			}
+
+			outputBin.output = prediction.makeOutput(phase);
+			
+			// All other bins are locked in phase
+			for (int c = 0; c < channels; ++c) {
+				if (c != maxChannel) {
+					auto &channelBin = bandsForChannel(c)[b];
+					auto &channelPrediction = predictionsForChannel(c)[b];
+					
+					Complex channelTwist = signalsmith::perf::mul<true>(channelPrediction.input, prediction.input);
+					Complex channelPhase = signalsmith::perf::mul(outputBin.output, channelTwist);
+					channelBin.output = channelPrediction.makeOutput(channelPhase);
+				}
+			}
+		}
+
+		if (newSpectrum) {
+			for (auto &bin : channelBands) {
+				bin.prevOutput = bin.output;
+				bin.prevInput = bin.input;
+			}
+		} else {
+			for (auto &bin : channelBands) bin.prevOutput = bin.output;
+		}
+	}
+	
+	// Produces smoothed energy across all channels
+	void smoothEnergy(Sample smoothingBins) {
+		Sample smoothingSlew = 1/(1 + smoothingBins*Sample(0.5));
+		for (auto &e : energy) e = 0;
+		for (int c = 0; c < channels; ++c) {
+			Band *bins = bandsForChannel(c);
+			for (int b = 0; b < bands; ++b) {
+				Sample e = std::norm(bins[b].input);
+				bins[b].inputEnergy = e; // Used for interpolating prediction energy
+				energy[b] += e;
+			}
+		}
+		for (int b = 0; b < bands; ++b) {
+			smoothedEnergy[b] = energy[b];
+		}
+		Sample e = 0;
+		for (int repeat = 0; repeat < 2; ++repeat) {
+			for (int b = bands - 1; b >= 0; --b) {
+				e += (smoothedEnergy[b] - e)*smoothingSlew;
+				smoothedEnergy[b] = e;
+			}
+			for (int b = 0; b < bands; ++b) {
+				e += (smoothedEnergy[b] - e)*smoothingSlew;
+				smoothedEnergy[b] = e;
+			}
+		}
+	}
+	
+	Sample mapFreq(Sample freq) const {
+		if (customFreqMap) return customFreqMap(freq);
+		if (freq > freqTonalityLimit) {
+			Sample diff = freq - freqTonalityLimit;
+			return freqTonalityLimit*freqMultiplier + diff;
+		}
+		return freq*freqMultiplier;
+	}
+	
+	// Identifies spectral peaks using energy across all channels
+	void findPeaks(Sample smoothingBins) {
+		smoothEnergy(smoothingBins);
+
+		peaks.resize(0);
+		
+		int start = 0;
+		while (start < bands) {
+			if (energy[start] > smoothedEnergy[start]) {
+				int end = start;
+				Sample bandSum = 0, energySum = 0;
+				while (end < bands && energy[end] > smoothedEnergy[end]) {
+					bandSum += end*energy[end];
+					energySum += energy[end];
+					++end;
+				}
+				Sample avgBand = bandSum/energySum;
+				Sample avgFreq = bandToFreq(avgBand);
+				peaks.emplace_back(Peak{avgBand, freqToBand(mapFreq(avgFreq))});
+
+				start = end;
+			}
+			++start;
+		}
+	}
+	
+	void updateOutputMap() {
+		if (peaks.empty()) {
+			for (int b = 0; b < bands; ++b) {
+				outputMap[b] = {Sample(b), 1};
+			}
+			return;
+		}
+		Sample bottomOffset = peaks[0].input - peaks[0].output;
+		for (int b = 0; b < std::min<int>(bands, std::ceil(peaks[0].output)); ++b) {
+			outputMap[b] = {b + bottomOffset, 1};
+		}
+		// Interpolate between points
+		for (size_t p = 1; p < peaks.size(); ++p) {
+			const Peak &prev = peaks[p - 1], &next = peaks[p];
+			Sample rangeScale = 1/(next.output - prev.output);
+			Sample outOffset = prev.input - prev.output;
+			Sample outScale = next.input - next.output - prev.input + prev.output;
+			Sample gradScale = outScale*rangeScale;
+			int startBin = std::max<int>(0, std::ceil(prev.output));
+			int endBin = std::min<int>(bands, std::ceil(next.output));
+			for (int b = startBin; b < endBin; ++b) {
+				Sample r = (b - prev.output)*rangeScale;
+				Sample h = r*r*(3 - 2*r);
+				Sample outB = b + outOffset + h*outScale;
+				
+				Sample gradH = 6*r*(1 - r);
+				Sample gradB = 1 + gradH*gradScale;
+				
+				outputMap[b] = {outB, gradB};
+			}
+		}
+		Sample topOffset = peaks.back().input - peaks.back().output;
+		for (int b = std::max<int>(0, peaks.back().output); b < bands; ++b) {
+			outputMap[b] = {b + topOffset, 1};
+		}
+	}
+};
+
+}} // namespace
+#endif // include guard

--- a/featured/aida-x-convolver/CMakeLists.txt
+++ b/featured/aida-x-convolver/CMakeLists.txt
@@ -1,0 +1,46 @@
+#cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.7.2)
+project(aida-x-convolver VERSION 0.9.0)
+
+set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+#set(CMAKE_C_VISIBILITY_PRESET hidden)
+#set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
+
+# set optimization flags
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -fPIC -shared -O3 -mcpu=cortex-a8 -mtune=cortex-a8 -mfloat-abi=hard -mfpu=neon -ftree-vectorize -ffast-math -fprefetch-loop-arrays -funroll-loops -funsafe-loop-optimizations -fno-finite-math-only")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -static-libstdc++ -Wl,-Ofast -Wl,--as-needed -Wl,--strip-debug")
+message("CMAKE_CXX_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_CXX_FLAGS_RELEASE}")
+message("CMAKE_SHARED_LINKER_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
+
+# configure executable
+add_library(aida-x-convolver SHARED
+    aida-x-convolver.cpp
+    ../../common/Biquad.cpp
+    ../../modules/FFTConvolver/AudioFFT.cpp
+    ../../modules/FFTConvolver/FFTConvolver.cpp
+    ../../modules/FFTConvolver/TwoStageFFTConvolver.cpp
+    ../../modules/FFTConvolver/Utilities.cpp
+    ../../modules/r8brain/pffft.cpp
+    ../../modules/r8brain/r8bbase.cpp)
+
+# include and link directories
+include_directories(aida-x-convolver
+    ./
+    ../../resources
+    ../../common
+    ../../modules/dr_libs
+    ../../modules/FFTConvolver
+    ../../modules/r8brain)
+
+target_link_libraries(aida-x-convolver PRIVATE pthread)
+set_target_properties(aida-x-convolver PROPERTIES PREFIX "")
+
+# config install
+install(TARGETS aida-x-convolver
+    DESTINATION bins/aida-x-convolver)

--- a/featured/aida-x-convolver/aida-x-convolver.cpp
+++ b/featured/aida-x-convolver/aida-x-convolver.cpp
@@ -1,0 +1,181 @@
+/*
+ * AIDA-X Convolver plugin for Chaos Audio
+ * Copyright (C) 2024 Massimo Pennazio <maxipenna@libero.it>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "dsp.hpp"
+
+#include <Eq2Bands.hpp>
+#include <ValueSmoother.hpp>
+
+/* 3rd-party  */
+#define DR_FLAC_IMPLEMENTATION
+#include "dr_flac.h"
+#define DR_WAV_IMPLEMENTATION
+#include "dr_wav.h"
+
+// -Wunused-variable
+#include "CDSPResampler.h"
+
+// Must be last
+#include <FFTConvolver.h>
+
+using namespace fftconvolver;
+
+class AidaXConvolver : public dsp {
+private:
+    // Define your private variables here
+    FFTConvolver* irs[MAXFILES] = {nullptr};
+    uint16_t irBlockSize = 1024;
+    uint8_t irIndex;
+    Eq2Bands* eq2Bands = nullptr;
+
+public:
+    float knobs_old[MAXKNOBS];
+
+    AidaXConvolver() {
+        // Initialize your plugin here
+    }
+
+    ~AidaXConvolver() {
+        // Clean up your plugin here
+        for (int i=0; i<MAXFILES; ++i) {
+            if (irs[i] != nullptr) {
+                delete irs[i];
+                irs[i] = nullptr;
+            }
+        }
+        if (eq2Bands != nullptr) {
+            delete eq2Bands;
+        }
+    }
+
+    uint16_t getIrBlockSize() {
+        return irBlockSize;
+    }
+
+    /* @TODO: warning!!! This is heavy and should NEVER be used from an audio rt thread */
+    void loadImpulseResponses() {
+        printf("Loading impulse responses\n");
+        printf("Ir block size: %d\n", getIrBlockSize());
+        for (int i=0; i<MAXFILES; ++i) {
+            if (irs[i] != nullptr) {
+                delete irs[i];
+                irs[i] = nullptr;
+            }
+            if (getFilePath(i).empty()) {
+                continue;
+            }
+            printf("Loading ir from path: %s\n", getFilePath(i).c_str());
+            // Understand extension of the file, if .wav or .flac
+            std::string ext = getFilePath(i).substr(getFilePath(i).find_last_of(".") + 1);
+            if (ext == "wav") {
+                drwav_uint64 fileTotalFrames;
+                unsigned int fileSampleRate;
+                unsigned int fileChannels;
+                float* data = drwav_open_file_and_read_pcm_frames_f32(getFilePath(i).c_str(), &fileChannels, &fileSampleRate, &fileTotalFrames, NULL);
+                if (data == nullptr) {
+                    printf("Error loading ir from path: %s\n", getFilePath(i).c_str());
+                    continue;
+                }
+                if (fileSampleRate != getSampleRate()) {
+                    r8b::CDSPResampler16IR resampler(fileSampleRate, getSampleRate(), fileTotalFrames);
+                    const int numResampledFrames = resampler.getMaxOutLen(0);
+                    if (numResampledFrames > 0) {
+                        float* resampledData = new float[numResampledFrames];
+                        printf("Resampling ir from %d to %d\n", fileSampleRate, getSampleRate());
+                        resampler.oneshot(data, fileTotalFrames, resampledData, numResampledFrames);
+                        data = resampledData;
+                        fileTotalFrames = numResampledFrames;
+                    } else {
+                        drwav_free(data, NULL);
+                        continue;
+                    }
+                }
+                if (fileChannels > 1) {
+                    // Assuming multi-channel in an interleaved format, convert to mono
+                    printf("Converting multi-channel file %s to mono\n", getFilePath(i).c_str());
+                    for (drwav_uint64 i=0, j=0; j<fileTotalFrames; ++i, j+=fileChannels)
+                        data[i] = data[j];
+                    fileTotalFrames /= fileChannels;
+                }
+                // @TODO: perform ir volume normalization here
+                irs[i] = new FFTConvolver();
+                if (!irs[i]->init(getIrBlockSize(), data, fileTotalFrames)) {
+                    printf("Error loading ir from path: %s\n", getFilePath(i).c_str());
+                    delete irs[i];
+                    irs[i] = nullptr;
+                }
+                drwav_free(data, NULL);
+            } else {
+                // @TODO: implement loading of flac files
+                printf("Unsupported format: %s\n", getFilePath(i).c_str());
+            }
+        }
+    }
+
+    virtual void instanceConstants() override {
+        // Implement the pure virtual function from the base class here
+        // Set the constants for your plugin here
+        version = "0.9.0";
+        name = "aida-x-convolver";
+        if (eq2Bands != nullptr) {
+            delete eq2Bands;
+        }
+        eq2Bands = new Eq2Bands(getSampleRate());
+        // Initialize controls, mapping to the correct values
+        knobs[0] = 0.0f;
+        knobs[1] = MAP(eq2Bands->bass_freq, 80.0f, 480.0f, 0.0f, 10.0f);
+        knobs[2] = MAP(eq2Bands->treble_freq, 1500.0f, getNyquist(), 0.0f, 10.0f);
+        switches[1] = UP; /* Bypass 2-bands equalizer */
+        knobs_old[0] = knobs[0];
+        knobs_old[1] = knobs[1];
+        knobs_old[2] = knobs[2];
+        irIndex = SELECTOR(knobs[0], MAXFILES);
+        loadImpulseResponses();
+    }
+
+    virtual void compute(int count, FAUSTFLOAT* input0, FAUSTFLOAT* output0) override {
+        // Implement the compute method here
+        // Update ir index only if the knob has changed
+        if (knobs[0] != knobs_old[0]) {
+            knobs_old[0] = knobs[0];
+            irIndex = SELECTOR(knobs[0], MAXFILES);
+        }
+        // Update eq2Bands only if enabled and if the knob has changed
+        if (eq2Bands != nullptr && switches[1] == DOWN) {
+            if (knobs[1] != knobs_old[1]) {
+                knobs_old[1] = knobs[1];
+                eq2Bands->bass_freq = MAP(knobs_old[1], 0.0f, 10.0f, 80.0f, 480.0f);
+                eq2Bands->updateBass();
+            }
+            if (knobs[2] != knobs_old[2]) {
+                knobs_old[2] = knobs[2];
+                eq2Bands->treble_freq = MAP(knobs_old[2], 0.0f, 10.0f, 1500.0f, getNyquist());
+                eq2Bands->updateTreble();
+            }
+            eq2Bands->process(count, input0, output0);
+        } else {
+            std::memcpy(output0, input0, sizeof(FAUSTFLOAT)*count);
+        }
+        // Apply ir if valid
+        if (irs[irIndex] == nullptr) {
+            return;
+        } else {
+            irs[irIndex]->process(output0, output0, count);
+        }
+    }
+
+    // If you need to override any other methods from the base class, you can do so here
+};
+
+extern "C" dsp* create() {
+    return new AidaXConvolver();
+}
+
+extern "C" void destroy(dsp* p) {
+    delete p;
+}
+
+extern "C" const char* dsp_version = DSP_VERSION;

--- a/featured/aida-x-player/CMakeLists.txt
+++ b/featured/aida-x-player/CMakeLists.txt
@@ -1,0 +1,56 @@
+#cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.7.2)
+project(aida-x-player VERSION 1.1.0)
+
+set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
+
+# if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|amd64|AMD64|i.86|x64|X64|x86|x86_64|X86)$")
+#   set(RTNEURAL_XSIMD TRUE CACHE BOOL "Use RTNeural with this backend")
+#   set(RTNEURAL_EIGEN FALSE CACHE BOOL "Use RTNeural with this backend")
+# else()
+set(RTNEURAL_XSIMD FALSE CACHE BOOL "Use RTNeural with this backend")
+set(RTNEURAL_EIGEN TRUE CACHE BOOL "Use RTNeural with this backend")
+# endif()
+
+message("RTNEURAL_XSIMD in ${CMAKE_PROJECT_NAME} = ${RTNEURAL_XSIMD}, using processor type ${CMAKE_SYSTEM_PROCESSOR} and system name ${CMAKE_SYSTEM_NAME}")
+message("RTNEURAL_EIGEN in ${CMAKE_PROJECT_NAME} = ${RTNEURAL_EIGEN}, using processor type ${CMAKE_SYSTEM_PROCESSOR} and system name ${CMAKE_SYSTEM_NAME}")
+
+# set optimization flags
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -fPIC -shared -O3 -mcpu=cortex-a8 -mtune=cortex-a8 -mfloat-abi=hard -mfpu=neon -ftree-vectorize -ffast-math -fprefetch-loop-arrays -funroll-loops -funsafe-loop-optimizations -fno-finite-math-only")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -static-libstdc++ -Wl,-Ofast -Wl,--as-needed -Wl,--strip-debug")
+message("CMAKE_CXX_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_CXX_FLAGS_RELEASE}")
+message("CMAKE_SHARED_LINKER_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
+
+# add external libraries
+add_subdirectory(../../modules/RTNeural ${CMAKE_CURRENT_BINARY_DIR}/RTNeural)
+
+# configure executable
+add_library(aida-x-player SHARED
+    aida-x-player.cpp)
+
+# include and link directories
+include_directories(aida-x-player
+    ./
+    ../../resources
+    ../../common
+    ../../modules/RTNeural/modules/json
+    ../../modules/RTNeural)
+
+link_directories(aida-x-player
+    ../../modules/RTNeural
+    ../../modules/RTNeural/modules/json)
+
+target_link_libraries(aida-x-player PRIVATE RTNeural)
+set_target_properties(aida-x-player PROPERTIES PREFIX "")
+
+# config install
+install(TARGETS aida-x-player
+    DESTINATION bins/aida-x-player)

--- a/featured/aida-x-player/aida-x-player.cpp
+++ b/featured/aida-x-player/aida-x-player.cpp
@@ -1,0 +1,326 @@
+/*
+ * AIDA-X Player plugin for Chaos Audio
+ * Copyright (C) 2024 Massimo Pennazio <maxipenna@libero.it>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "dsp.hpp"
+
+#include <ValueSmoother.hpp>
+#include <RTNeural/RTNeural.h>
+#include <model_variant.hpp>
+
+// @TODO: unsupported for now
+#define AIDADSP_CONDITIONED_MODELS 0
+
+struct DynamicModel {
+    ModelVariantType variant;
+    char* path;
+    bool input_skip; /* Means the model has been trained with first input element skipped to the output */
+    float input_gain;
+    float output_gain;
+    float samplerate;
+#if AIDADSP_CONDITIONED_MODELS
+    LinearValueSmoother param1Coeff;
+    LinearValueSmoother param2Coeff;
+    bool paramFirstRun;
+#endif
+};
+
+class AidaXPlayer : public dsp {
+private:
+    // Define your private variables here
+    DynamicModel* models[MAXFILES] = {nullptr};
+    uint8_t modelIndex;
+
+    /**
+     * This function carries model calculations for snapshot models, models with one parameter and
+     * models with two parameters.
+    */
+    void applyModel(DynamicModel* model, float* out, uint32_t n_samples)
+    {
+        const bool input_skip = model->input_skip;
+        const float input_gain = model->input_gain;
+        const float output_gain = model->output_gain;
+    #if AIDADSP_CONDITIONED_MODELS
+        LinearValueSmoother& param1Coeff = model->param1Coeff;
+        LinearValueSmoother& param2Coeff = model->param2Coeff;
+    #endif
+
+        std::visit (
+            [input_skip, &out, n_samples, input_gain, output_gain
+    #if AIDADSP_CONDITIONED_MODELS
+            , &param1Coeff, &param2Coeff
+    #endif
+            ] (auto&& custom_model)
+            {
+                using ModelType = std::decay_t<decltype (custom_model)>;
+                if constexpr (ModelType::input_size == 1)
+                {
+                    if (input_skip)
+                    {
+                        for (uint32_t i=0; i<n_samples; ++i) {
+                            out[i] *= input_gain;
+                            out[i] += custom_model.forward (out + i);
+                            out[i] *= output_gain;
+                        }
+                    }
+                    else
+                    {
+                        for (uint32_t i=0; i<n_samples; ++i) {
+                            out[i] *= input_gain;
+                            out[i] = custom_model.forward (out + i);
+                            out[i] *= output_gain;
+                        }
+                    }
+                }
+    #if AIDADSP_CONDITIONED_MODELS
+                else if constexpr (ModelType::input_size == 2)
+                {
+                    float inArray1 alignas(RTNEURAL_DEFAULT_ALIGNMENT)[2] = { 0.0, 0.0 };
+                    if (input_skip)
+                    {
+                        for (uint32_t i=0; i<n_samples; ++i) {
+                            out[i] *= input_gain;
+                            inArray1[0] = out[i];
+                            inArray1[1] = param1Coeff.next();
+                            out[i] += custom_model.forward (inArray1);
+                            out[i] *= output_gain;
+                        }
+                    }
+                    else
+                    {
+                        for (uint32_t i=0; i<n_samples; ++i) {
+                            out[i] *= input_gain;
+                            inArray1[0] = out[i];
+                            inArray1[1] = param1Coeff.next();
+                            out[i] = custom_model.forward (inArray1);
+                            out[i] *= output_gain;
+                        }
+                    }
+                }
+                else if constexpr (ModelType::input_size == 3)
+                {
+                    float inArray2 alignas(RTNEURAL_DEFAULT_ALIGNMENT)[3] = { 0.0, 0.0, 0.0 };
+                    if (input_skip)
+                    {
+                        for (uint32_t i=0; i<n_samples; ++i) {
+                            out[i] *= input_gain;
+                            inArray2[0] = out[i];
+                            inArray2[1] = param1Coeff.next();
+                            inArray2[2] = param2Coeff.next();
+                            out[i] += custom_model.forward (inArray2);
+                            out[i] *= output_gain;
+                        }
+                    }
+                    else
+                    {
+                        for (uint32_t i=0; i<n_samples; ++i) {
+                            out[i] *= input_gain;
+                            inArray2[0] = out[i];
+                            inArray2[1] = param1Coeff.next();
+                            inArray2[2] = param2Coeff.next();
+                            out[i] = custom_model.forward (inArray2);
+                            out[i] *= output_gain;
+                        }
+                    }
+                }
+    #endif
+            },
+            model->variant
+        );
+    }
+
+    /**
+     * This function loads a pre-trained neural model from a json file
+    */
+    DynamicModel* loadModelFromPath(const char* path) {
+        // Load the model from the path
+        int input_skip;
+        int input_size;
+        float input_gain;
+        float output_gain;
+        float model_samplerate = 0.0f;
+        nlohmann::json model_json;
+
+        try {
+            std::ifstream jsonStream(path, std::ifstream::binary);
+            jsonStream >> model_json;
+
+            /* Understand which model type to load */
+            input_size = model_json["in_shape"].back().get<int>();
+            if (input_size > MAX_INPUT_SIZE) {
+                throw std::invalid_argument("Value for input_size not supported");
+            }
+
+            if (model_json["in_skip"].is_number()) {
+                input_skip = model_json["in_skip"].get<int>();
+                if (input_skip > 1)
+                    throw std::invalid_argument("Values for in_skip > 1 are not supported");
+            }
+            else {
+                input_skip = 0;
+            }
+
+            if (model_json["in_gain"].is_number()) {
+                input_gain = DB_CO(model_json["in_gain"].get<float>());
+            }
+            else {
+                input_gain = 1.0f;
+            }
+
+            if (model_json["out_gain"].is_number()) {
+                output_gain = DB_CO(model_json["out_gain"].get<float>());
+            }
+            else {
+                output_gain = 1.0f;
+            }
+
+            if (model_json["metadata"]["samplerate"].is_number()) {
+                model_samplerate = model_json["metadata"]["samplerate"].get<float>();
+            }
+            else if (model_json["samplerate"].is_number()) {
+                model_samplerate = model_json["samplerate"].get<float>();
+            }
+            else {
+                throw std::invalid_argument("No samplerate was present in the model file");
+            }
+
+            if (model_samplerate != float(getSampleRate())) {
+                throw std::invalid_argument("Model samplerate does not match with plugin samplerate");
+            }
+
+            printf("Successfully loaded json file: %s\n", path);
+        }
+        catch (const std::exception& e) {
+            printf("Unable to load json file: %s\nError: %s\n", path, e.what());
+            return nullptr;
+        }
+
+        std::unique_ptr<DynamicModel> model = std::make_unique<DynamicModel>();
+
+        try {
+            if (! custom_model_creator (model_json, model->variant))
+                throw std::runtime_error ("Unable to identify a known model architecture!");
+
+            std::visit (
+                [&model_json] (auto&& custom_model)
+                {
+                    using ModelType = std::decay_t<decltype (custom_model)>;
+                    if constexpr (! std::is_same_v<ModelType, NullModel>)
+                    {
+                        custom_model.parseJson (model_json, true);
+                        custom_model.reset();
+                    }
+                },
+                model->variant);
+            printf("%s %d: mdl rst!\n", __func__, __LINE__);
+        }
+        catch (const std::exception& e) {
+            printf("Error loading model: %s\n", e.what());
+            return nullptr;
+        }
+
+        /* Save extra info */
+        model->path = strdup(path);
+        model->input_skip = input_skip != 0;
+        model->input_gain = input_gain;
+        model->output_gain = output_gain;
+        model->samplerate = model_samplerate;
+    #if AIDADSP_CONDITIONED_MODELS
+        model->param1Coeff.setSampleRate(model_samplerate);
+        model->param1Coeff.setTimeConstant(0.1f);
+        model->param1Coeff.setTargetValue(old_param1);
+        model->param1Coeff.clearToTargetValue();
+        model->param2Coeff.setSampleRate(model_samplerate);
+        model->param2Coeff.setTimeConstant(0.1f);
+        model->param2Coeff.setTargetValue(old_param2);
+        model->param2Coeff.clearToTargetValue();
+        model->paramFirstRun = true;
+    #endif
+
+        /* @TODO: init */
+        float out[2048] = {};
+        applyModel(model.get(), out, 2048);
+
+        return model.release();
+    }
+
+public:
+    float knobs_old[MAXKNOBS];
+
+    AidaXPlayer() {
+        // Initialize your plugin here
+    }
+
+    ~AidaXPlayer() {
+        // Clean up your plugin here
+        for (int i=0; i<MAXFILES; ++i) {
+            if (models[i] != nullptr) {
+                delete models[i];
+                models[i] = nullptr;
+            }
+        }
+    }
+
+    /* @TODO: warning!!! This is heavy and should NEVER be used from an audio rt thread */
+    void loadModels() {
+        for (int i=0; i<MAXFILES; ++i) {
+            if (models[i] != nullptr) {
+                delete models[i];
+                models[i] = nullptr;
+            }
+            if (getFilePath(i).empty()) {
+                continue;
+            }
+            printf("Loading model from path: %s\n", getFilePath(i).c_str());
+            DynamicModel* newmodel = loadModelFromPath(getFilePath(i).c_str());
+            if (newmodel == nullptr) {
+                printf("Error loading model from path: %s\n", getFilePath(i).c_str());
+                continue;
+            }
+            else {
+                models[i] = newmodel;
+            }
+        }
+    }
+
+    virtual void instanceConstants() override {
+        // Implement the pure virtual function from the base class here
+        // Set the constants for your plugin here
+        version = "0.9.0";
+        name = "aida-x-player";
+        // Initialize controls, mapping to the correct values
+        knobs[0] = 0.0f;
+        knobs_old[0] = knobs[0];
+        modelIndex = SELECTOR(knobs[0], MAXFILES);
+        loadModels();
+    }
+
+    virtual void compute(int count, FAUSTFLOAT* input0, FAUSTFLOAT* output0) override {
+        // Implement the compute method here
+        // Update model index only if the knob has changed
+        if (knobs[0] != knobs_old[0]) {
+            knobs_old[0] = knobs[0];
+            modelIndex = SELECTOR(knobs[0], MAXFILES);
+        }
+        // Apply model if valid
+        if (models[modelIndex] == nullptr) {
+            return;
+        } else {
+            applyModel(models[modelIndex], output0, count);
+        }
+    }
+
+    // If you need to override any other methods from the base class, you can do so here
+};
+
+extern "C" dsp* create() {
+    return new AidaXPlayer();
+}
+
+extern "C" void destroy(dsp* p) {
+    delete p;
+}
+
+extern "C" const char* dsp_version = DSP_VERSION;

--- a/featured/aida-x-player/model_variant.hpp
+++ b/featured/aida-x-player/model_variant.hpp
@@ -1,0 +1,875 @@
+#include <variant>
+#include <RTNeural/RTNeural.h>
+
+#define MAX_INPUT_SIZE 3
+struct NullModel { static constexpr int input_size = 0; static constexpr int output_size = 0; };
+using ModelType_GRU_8_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 8>, RTNeural::DenseT<float, 8, 1>>;
+using ModelType_GRU_8_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 8>, RTNeural::DenseT<float, 8, 1>>;
+using ModelType_GRU_8_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 8>, RTNeural::DenseT<float, 8, 1>>;
+using ModelType_GRU_12_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 12>, RTNeural::DenseT<float, 12, 1>>;
+using ModelType_GRU_12_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 12>, RTNeural::DenseT<float, 12, 1>>;
+using ModelType_GRU_12_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 12>, RTNeural::DenseT<float, 12, 1>>;
+using ModelType_GRU_16_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 16>, RTNeural::DenseT<float, 16, 1>>;
+using ModelType_GRU_16_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 16>, RTNeural::DenseT<float, 16, 1>>;
+using ModelType_GRU_16_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 16>, RTNeural::DenseT<float, 16, 1>>;
+using ModelType_GRU_20_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 20>, RTNeural::DenseT<float, 20, 1>>;
+using ModelType_GRU_20_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 20>, RTNeural::DenseT<float, 20, 1>>;
+using ModelType_GRU_20_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 20>, RTNeural::DenseT<float, 20, 1>>;
+using ModelType_GRU_24_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 24>, RTNeural::DenseT<float, 24, 1>>;
+using ModelType_GRU_24_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 24>, RTNeural::DenseT<float, 24, 1>>;
+using ModelType_GRU_24_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 24>, RTNeural::DenseT<float, 24, 1>>;
+using ModelType_GRU_32_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 32>, RTNeural::DenseT<float, 32, 1>>;
+using ModelType_GRU_32_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 32>, RTNeural::DenseT<float, 32, 1>>;
+using ModelType_GRU_32_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 32>, RTNeural::DenseT<float, 32, 1>>;
+using ModelType_GRU_40_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 40>, RTNeural::DenseT<float, 40, 1>>;
+using ModelType_GRU_40_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 40>, RTNeural::DenseT<float, 40, 1>>;
+using ModelType_GRU_40_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 40>, RTNeural::DenseT<float, 40, 1>>;
+using ModelType_GRU_64_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 64>, RTNeural::DenseT<float, 64, 1>>;
+using ModelType_GRU_64_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 64>, RTNeural::DenseT<float, 64, 1>>;
+using ModelType_GRU_64_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 64>, RTNeural::DenseT<float, 64, 1>>;
+using ModelType_GRU_80_1 = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 80>, RTNeural::DenseT<float, 80, 1>>;
+using ModelType_GRU_80_2 = RTNeural::ModelT<float, 2, 1, RTNeural::GRULayerT<float, 2, 80>, RTNeural::DenseT<float, 80, 1>>;
+using ModelType_GRU_80_3 = RTNeural::ModelT<float, 3, 1, RTNeural::GRULayerT<float, 3, 80>, RTNeural::DenseT<float, 80, 1>>;
+using ModelType_LSTM_8_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 8>, RTNeural::DenseT<float, 8, 1>>;
+using ModelType_LSTM_8_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 8>, RTNeural::DenseT<float, 8, 1>>;
+using ModelType_LSTM_8_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 8>, RTNeural::DenseT<float, 8, 1>>;
+using ModelType_LSTM_12_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 12>, RTNeural::DenseT<float, 12, 1>>;
+using ModelType_LSTM_12_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 12>, RTNeural::DenseT<float, 12, 1>>;
+using ModelType_LSTM_12_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 12>, RTNeural::DenseT<float, 12, 1>>;
+using ModelType_LSTM_16_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 16>, RTNeural::DenseT<float, 16, 1>>;
+using ModelType_LSTM_16_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 16>, RTNeural::DenseT<float, 16, 1>>;
+using ModelType_LSTM_16_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 16>, RTNeural::DenseT<float, 16, 1>>;
+using ModelType_LSTM_20_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 20>, RTNeural::DenseT<float, 20, 1>>;
+using ModelType_LSTM_20_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 20>, RTNeural::DenseT<float, 20, 1>>;
+using ModelType_LSTM_20_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 20>, RTNeural::DenseT<float, 20, 1>>;
+using ModelType_LSTM_24_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 24>, RTNeural::DenseT<float, 24, 1>>;
+using ModelType_LSTM_24_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 24>, RTNeural::DenseT<float, 24, 1>>;
+using ModelType_LSTM_24_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 24>, RTNeural::DenseT<float, 24, 1>>;
+using ModelType_LSTM_32_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 32>, RTNeural::DenseT<float, 32, 1>>;
+using ModelType_LSTM_32_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 32>, RTNeural::DenseT<float, 32, 1>>;
+using ModelType_LSTM_32_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 32>, RTNeural::DenseT<float, 32, 1>>;
+using ModelType_LSTM_40_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 40>, RTNeural::DenseT<float, 40, 1>>;
+using ModelType_LSTM_40_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 40>, RTNeural::DenseT<float, 40, 1>>;
+using ModelType_LSTM_40_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 40>, RTNeural::DenseT<float, 40, 1>>;
+using ModelType_LSTM_64_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 64>, RTNeural::DenseT<float, 64, 1>>;
+using ModelType_LSTM_64_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 64>, RTNeural::DenseT<float, 64, 1>>;
+using ModelType_LSTM_64_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 64>, RTNeural::DenseT<float, 64, 1>>;
+using ModelType_LSTM_80_1 = RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 80>, RTNeural::DenseT<float, 80, 1>>;
+using ModelType_LSTM_80_2 = RTNeural::ModelT<float, 2, 1, RTNeural::LSTMLayerT<float, 2, 80>, RTNeural::DenseT<float, 80, 1>>;
+using ModelType_LSTM_80_3 = RTNeural::ModelT<float, 3, 1, RTNeural::LSTMLayerT<float, 3, 80>, RTNeural::DenseT<float, 80, 1>>;
+using ModelVariantType = std::variant<NullModel,ModelType_GRU_8_1,ModelType_GRU_8_2,ModelType_GRU_8_3,ModelType_GRU_12_1,ModelType_GRU_12_2,ModelType_GRU_12_3,ModelType_GRU_16_1,ModelType_GRU_16_2,ModelType_GRU_16_3,ModelType_GRU_20_1,ModelType_GRU_20_2,ModelType_GRU_20_3,ModelType_GRU_24_1,ModelType_GRU_24_2,ModelType_GRU_24_3,ModelType_GRU_32_1,ModelType_GRU_32_2,ModelType_GRU_32_3,ModelType_GRU_40_1,ModelType_GRU_40_2,ModelType_GRU_40_3,ModelType_GRU_64_1,ModelType_GRU_64_2,ModelType_GRU_64_3,ModelType_GRU_80_1,ModelType_GRU_80_2,ModelType_GRU_80_3,ModelType_LSTM_8_1,ModelType_LSTM_8_2,ModelType_LSTM_8_3,ModelType_LSTM_12_1,ModelType_LSTM_12_2,ModelType_LSTM_12_3,ModelType_LSTM_16_1,ModelType_LSTM_16_2,ModelType_LSTM_16_3,ModelType_LSTM_20_1,ModelType_LSTM_20_2,ModelType_LSTM_20_3,ModelType_LSTM_24_1,ModelType_LSTM_24_2,ModelType_LSTM_24_3,ModelType_LSTM_32_1,ModelType_LSTM_32_2,ModelType_LSTM_32_3,ModelType_LSTM_40_1,ModelType_LSTM_40_2,ModelType_LSTM_40_3,ModelType_LSTM_64_1,ModelType_LSTM_64_2,ModelType_LSTM_64_3,ModelType_LSTM_80_1,ModelType_LSTM_80_2,ModelType_LSTM_80_3>;
+
+inline bool is_model_type_ModelType_GRU_8_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 8;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_8_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 8;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_8_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 8;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_12_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 12;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_12_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 12;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_12_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 12;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_16_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 16;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_16_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 16;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_16_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 16;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_20_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 20;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_20_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 20;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_20_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 20;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_24_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 24;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_24_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 24;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_24_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 24;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_32_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 32;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_32_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 32;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_32_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 32;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_40_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 40;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_40_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 40;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_40_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 40;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_64_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 64;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_64_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 64;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_64_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 64;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_80_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 80;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_80_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 80;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_GRU_80_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "gru";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 80;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_8_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 8;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_8_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 8;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_8_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 8;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_12_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 12;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_12_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 12;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_12_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 12;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_16_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 16;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_16_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 16;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_16_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 16;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_20_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 20;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_20_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 20;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_20_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 20;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_24_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 24;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_24_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 24;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_24_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 24;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_32_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 32;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_32_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 32;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_32_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 32;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_40_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 40;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_40_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 40;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_40_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 40;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_64_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 64;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_64_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 64;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_64_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 64;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_80_1 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 80;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 1;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_80_2 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 80;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 2;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool is_model_type_ModelType_LSTM_80_3 (const nlohmann::json& model_json) {
+    const auto json_layers = model_json.at ("layers");
+    const auto rnn_layer_type = json_layers.at (0).at ("type").get<std::string>();
+    const auto is_layer_type_correct = rnn_layer_type == "lstm";
+    const auto hidden_size = json_layers.at (0).at ("shape").back().get<int>();
+    const auto is_hidden_size_correct = hidden_size == 80;
+    const auto input_size = model_json.at ("in_shape").back().get<int>();
+    const auto is_input_size_correct = input_size == 3;
+    return is_layer_type_correct && is_hidden_size_correct && is_input_size_correct;
+}
+
+inline bool custom_model_creator (const nlohmann::json& model_json, ModelVariantType& model) {
+    if (is_model_type_ModelType_GRU_8_1 (model_json)) {
+        model.emplace<ModelType_GRU_8_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_8_2 (model_json)) {
+        model.emplace<ModelType_GRU_8_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_8_3 (model_json)) {
+        model.emplace<ModelType_GRU_8_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_12_1 (model_json)) {
+        model.emplace<ModelType_GRU_12_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_12_2 (model_json)) {
+        model.emplace<ModelType_GRU_12_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_12_3 (model_json)) {
+        model.emplace<ModelType_GRU_12_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_16_1 (model_json)) {
+        model.emplace<ModelType_GRU_16_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_16_2 (model_json)) {
+        model.emplace<ModelType_GRU_16_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_16_3 (model_json)) {
+        model.emplace<ModelType_GRU_16_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_20_1 (model_json)) {
+        model.emplace<ModelType_GRU_20_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_20_2 (model_json)) {
+        model.emplace<ModelType_GRU_20_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_20_3 (model_json)) {
+        model.emplace<ModelType_GRU_20_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_24_1 (model_json)) {
+        model.emplace<ModelType_GRU_24_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_24_2 (model_json)) {
+        model.emplace<ModelType_GRU_24_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_24_3 (model_json)) {
+        model.emplace<ModelType_GRU_24_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_32_1 (model_json)) {
+        model.emplace<ModelType_GRU_32_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_32_2 (model_json)) {
+        model.emplace<ModelType_GRU_32_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_32_3 (model_json)) {
+        model.emplace<ModelType_GRU_32_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_40_1 (model_json)) {
+        model.emplace<ModelType_GRU_40_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_40_2 (model_json)) {
+        model.emplace<ModelType_GRU_40_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_40_3 (model_json)) {
+        model.emplace<ModelType_GRU_40_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_64_1 (model_json)) {
+        model.emplace<ModelType_GRU_64_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_64_2 (model_json)) {
+        model.emplace<ModelType_GRU_64_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_64_3 (model_json)) {
+        model.emplace<ModelType_GRU_64_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_80_1 (model_json)) {
+        model.emplace<ModelType_GRU_80_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_80_2 (model_json)) {
+        model.emplace<ModelType_GRU_80_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_GRU_80_3 (model_json)) {
+        model.emplace<ModelType_GRU_80_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_8_1 (model_json)) {
+        model.emplace<ModelType_LSTM_8_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_8_2 (model_json)) {
+        model.emplace<ModelType_LSTM_8_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_8_3 (model_json)) {
+        model.emplace<ModelType_LSTM_8_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_12_1 (model_json)) {
+        model.emplace<ModelType_LSTM_12_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_12_2 (model_json)) {
+        model.emplace<ModelType_LSTM_12_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_12_3 (model_json)) {
+        model.emplace<ModelType_LSTM_12_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_16_1 (model_json)) {
+        model.emplace<ModelType_LSTM_16_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_16_2 (model_json)) {
+        model.emplace<ModelType_LSTM_16_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_16_3 (model_json)) {
+        model.emplace<ModelType_LSTM_16_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_20_1 (model_json)) {
+        model.emplace<ModelType_LSTM_20_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_20_2 (model_json)) {
+        model.emplace<ModelType_LSTM_20_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_20_3 (model_json)) {
+        model.emplace<ModelType_LSTM_20_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_24_1 (model_json)) {
+        model.emplace<ModelType_LSTM_24_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_24_2 (model_json)) {
+        model.emplace<ModelType_LSTM_24_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_24_3 (model_json)) {
+        model.emplace<ModelType_LSTM_24_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_32_1 (model_json)) {
+        model.emplace<ModelType_LSTM_32_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_32_2 (model_json)) {
+        model.emplace<ModelType_LSTM_32_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_32_3 (model_json)) {
+        model.emplace<ModelType_LSTM_32_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_40_1 (model_json)) {
+        model.emplace<ModelType_LSTM_40_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_40_2 (model_json)) {
+        model.emplace<ModelType_LSTM_40_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_40_3 (model_json)) {
+        model.emplace<ModelType_LSTM_40_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_64_1 (model_json)) {
+        model.emplace<ModelType_LSTM_64_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_64_2 (model_json)) {
+        model.emplace<ModelType_LSTM_64_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_64_3 (model_json)) {
+        model.emplace<ModelType_LSTM_64_3>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_80_1 (model_json)) {
+        model.emplace<ModelType_LSTM_80_1>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_80_2 (model_json)) {
+        model.emplace<ModelType_LSTM_80_2>();
+        return true;
+    }
+    else if (is_model_type_ModelType_LSTM_80_3 (model_json)) {
+        model.emplace<ModelType_LSTM_80_3>();
+        return true;
+    }
+    model.emplace<NullModel>();
+    return false;
+}

--- a/featured/aida-x-tests/CMakeLists.txt
+++ b/featured/aida-x-tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.10)
+
+# set the project name
+project(aida-x-tests)
+
+# specify the C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Set the flags for this directory
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O2")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,-O2")
+message("CMAKE_CXX_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_CXX_FLAGS_RELEASE}")
+message("CMAKE_SHARED_LINKER_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
+
+# Function to add an executable, set include directories, link libraries, and install
+function(add_executable_and_setup target_name source_file)
+    add_executable(${target_name} ${source_file})
+    include_directories(${target_name} ../../resources ../../common)
+    target_link_libraries(${target_name} PRIVATE dl)
+    install(TARGETS ${target_name} DESTINATION bins/tests/benchmark)
+endfunction()
+
+# Add the executables
+add_executable_and_setup(benchmark-player benchmark_player.cpp)
+add_executable_and_setup(benchmark-convolver benchmark_convolver.cpp)

--- a/featured/aida-x-tests/benchmark_convolver.cpp
+++ b/featured/aida-x-tests/benchmark_convolver.cpp
@@ -1,0 +1,69 @@
+#include <dlfcn.h>
+#include <iostream>
+#include "dsp.hpp" // Include the dsp header file
+
+using dsp_creator_t = dsp* (*)();
+
+int main(int argc, char **argv) {
+    if (argc != 5) {
+        std::cerr << "Usage: " << argv[0] << " <path_to_shared_object> <seconds> <sample_rate> <path_to_ir_file>\n";
+        return 1;
+    }
+
+    const char* libraryPath = argv[1];
+    int seconds = std::stoi(argv[2]);
+    int sampleRate = std::stoi(argv[3]);
+    const char* irFilePath = argv[4];
+
+    // Load the shared object
+    std::cout << "Loading library: " << libraryPath << '\n';
+    void* handle = dlopen(libraryPath, RTLD_NOW);
+    if (!handle) {
+        std::cerr << "Cannot open library: " << dlerror() << '\n';
+        return 1;
+    }
+
+    // Reset errors
+    dlerror();
+
+    // Load the version string
+    const char** version_string_ptr = reinterpret_cast<const char**>(dlsym(handle, "dsp_version"));
+    if (!version_string_ptr) {
+        std::cout << "The 'dsp_version' symbol does not exist in the shared library.\n";
+        return 1;
+    }
+
+    // Load the "create" symbol
+    std::cout << "Loading symbol: create\n";
+    dsp_creator_t create = reinterpret_cast<dsp_creator_t>(dlsym(handle, "create"));
+    const char *dlsym_error = dlerror();
+    if (dlsym_error) {
+        std::cerr << "Cannot load symbol 'create': " << dlsym_error << '\n';
+        dlclose(handle);
+        return 1;
+    }
+
+    // Create an instance of the class
+    std::cout << "Creating instance\n";
+    dsp* instance = create();
+
+    // Set sample rate
+    std::cout << "Setting sample rate: " << sampleRate << '\n';
+    instance->setSampleRate(sampleRate);
+
+    // Set file path
+    std::cout << "Setting file path: " << irFilePath << '\n';
+    instance->setFilePath(irFilePath);
+
+    // Invoking instanceConstants method
+    std::cout << "Invoking instanceConstants method\n";
+    instance->instanceConstants();
+
+    // Actually perform the benchmark
+    std::cout << "Invoking benchmark method\n";
+    instance->benchmark(seconds);
+
+    // Close the library
+    std::cout << "Deleting instance\n";
+    dlclose(handle);
+}

--- a/featured/aida-x-tests/benchmark_player.cpp
+++ b/featured/aida-x-tests/benchmark_player.cpp
@@ -1,0 +1,67 @@
+#include <dlfcn.h>
+#include <iostream>
+#include "dsp.hpp" // Include the dsp header file
+
+int main(int argc, char **argv) {
+    if (argc != 5) {
+        std::cerr << "Usage: " << argv[0] << " <path_to_shared_object> <seconds> <sample_rate> <path_to_model_file>\n";
+        return 1;
+    }
+
+    const char* libraryPath = argv[1];
+    int seconds = std::stoi(argv[2]);
+    int sampleRate = std::stoi(argv[3]);
+    const char* modelFilePath = argv[4];
+
+    // Load the shared object
+    std::cout << "Loading library: " << libraryPath << '\n';
+    void* handle = dlopen(libraryPath, RTLD_NOW);
+    if (!handle) {
+        std::cerr << "Cannot open library: " << dlerror() << '\n';
+        return 1;
+    }
+
+    // Reset errors
+    dlerror();
+
+    // Load the version string
+    const char** version_string_ptr = reinterpret_cast<const char**>(dlsym(handle, "dsp_version"));
+    if (!version_string_ptr) {
+        std::cout << "The 'dsp_version' symbol does not exist in the shared library.\n";
+        return 1;
+    }
+
+    // Load the "create" symbol
+    std::cout << "Loading symbol: create\n";
+    dsp_creator_t create = reinterpret_cast<dsp_creator_t>(dlsym(handle, "create"));
+    const char *dlsym_error = dlerror();
+    if (dlsym_error) {
+        std::cerr << "Cannot load symbol 'create': " << dlsym_error << '\n';
+        dlclose(handle);
+        return 1;
+    }
+
+    // Create an instance of the class
+    std::cout << "Creating instance\n";
+    dsp* instance = create();
+
+    // Set sample rate
+    std::cout << "Setting sample rate: " << sampleRate << '\n';
+    instance->setSampleRate(sampleRate);
+
+    // Set file path
+    std::cout << "Setting file path: " << modelFilePath << '\n';
+    instance->setFilePath(modelFilePath);
+
+    // Invoking instanceConstants method
+    std::cout << "Invoking instanceConstants method\n";
+    instance->instanceConstants();
+
+    // Actually perform the benchmark
+    std::cout << "Invoking benchmark method\n";
+    instance->benchmark(seconds);
+
+    // Close the library
+    std::cout << "Deleting instance\n";
+    dlclose(handle);
+}

--- a/resources/dsp.hpp
+++ b/resources/dsp.hpp
@@ -7,16 +7,36 @@
 #include <cmath>
 #include <math.h>
 
+#include <algorithm>
+#include <random>
+#include <chrono>
+
+#define DSP_VERSION "2.0.0"
+
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
 #endif
 
 #define MAXKNOBS 10
 #define MAXSWITCHES 5
+#define MAXFILES 5
 
 #ifndef Uint
 typedef unsigned int Uint;
 #endif
+
+/* Convert a value in dB's to a coefficent */
+#define DB_CO(g) ((g) > -90.0f ? powf(10.0f, (g) * 0.05f) : 0.0f)
+#define CO_DB(v) (20.0f * log10f(v))
+
+/* Define a macro to scale % to coeff */
+#define PC_CO(g) ((g) < 100.0f ? (g / 100.0f) : 1.0f)
+
+/* Define a macro to re-maps a number from one range to another  */
+#define MAP(x, in_min, in_max, out_min, out_max) (((x - in_min) * (out_max - out_min) / (in_max - in_min)) + out_min)
+
+/* Define a macro to implement a selector out of a knob */
+#define SELECTOR(knob, n) ((uint8_t)(knob * n) % n)
 
 struct dsp {
 	enum SWITCH_STATE{
@@ -25,19 +45,25 @@ struct dsp {
 		MIDDLE = 2
 	};
     private:
+		int fSampleRate = 44100;
+		std::string filePaths[MAXFILES];
+		bool trailsSetting = false;
 
 	protected:
 		std::string version;
     
     public:
-		int fSampleRate = 44100;
 		float knobs[MAXKNOBS];
 		SWITCH_STATE switches[MAXSWITCHES];
 		SWITCH_STATE stompSwitch;
 		std::string name;
-		
+		bool trailsAvailable = false;
+
         dsp() {
-        	name = "null";
+			name = "null";
+			version = "0.0.0";
+			for(int i=0;i<MAXFILES;++i)
+				filePaths[i]="";
         	for(int i=0;i<MAXKNOBS;++i)
         		knobs[i]=.5;
         	for(int i=0;i<MAXSWITCHES;++i)
@@ -74,6 +100,68 @@ struct dsp {
 		return version;
 	}
 
+	void setFilePath(std::string path, uint8_t index){
+		if(index<MAXFILES)
+			this->filePaths[index]=path;
+	}
+
+	void setFilePath(std::string path){
+		this->filePaths[0]=path;
+	}
+
+	std::string getFilePath(uint8_t index){
+		if(index<MAXFILES)
+			return filePaths[index];
+		else
+			return "";
+	}
+
+	std::string getFilePath(){
+		return filePaths[0];
+	}
+
+	std::string extractFileName(const std::string& path){
+		size_t pos = path.find_last_of("/\\");
+		if(pos != std::string::npos)
+			return path.substr(pos + 1);
+		else
+			return "";
+	}
+
+	std::string getFileName(uint8_t index){
+		if(index<MAXFILES){
+			return extractFileName(filePaths[index]);
+		}
+		else
+			return "";
+	}
+
+	std::string getFileName(){
+		return extractFileName(filePaths[0]);
+	}
+
+	void setSampleRate(int sampleRate){
+		fSampleRate = sampleRate;
+	}
+
+	int getSampleRate(){
+		return fSampleRate;
+	}
+
+	int getNyquist(){
+		return fSampleRate/2;
+	}
+
+	bool getTrailsVal(){
+		return trailsSetting;
+	}
+
+	void setTrailsVal(bool val){
+		if (trailsAvailable) {
+			trailsSetting = val;
+		}
+	}
+
 	virtual void setKnob(int num, float knobVal){
 		this->knobs[num] = knobVal;
 	}
@@ -108,10 +196,32 @@ struct dsp {
 	virtual void instanceConstants() = 0;
 
 	virtual void compute(int count, FAUSTFLOAT* inputs, FAUSTFLOAT* outputs) = 0;
+
+	virtual void benchmark(int seconds) {
+		printf("Starting benchmark\n");
+		const auto n_samples = static_cast<size_t>(fSampleRate * seconds);
+
+		// Generate input signal
+		printf("Generating input signal\n");
+		std::vector<float> input(n_samples);
+		std::default_random_engine generator;
+		std::uniform_real_distribution<float> distribution(-1.0, 1.0);
+		std::generate(input.begin(), input.end(), [&]() { return distribution(generator); });
+
+		std::vector<float> output(n_samples);
+
+		// Run benchmark
+		using clock_t = std::chrono::high_resolution_clock;
+		using second_t = std::chrono::duration<float>;
+		printf("Computing %d seconds of data @%dHz\n", seconds, fSampleRate);
+		auto start = clock_t::now();
+		compute(n_samples, input.data(), output.data());
+		float dur = std::chrono::duration_cast<second_t>(clock_t::now() - start).count();
+		printf("Processed %d seconds of signal in %f seconds\n", seconds, dur);
+		printf("%f x real-time\n", seconds / dur);
+	}
 };
 
-#endif
-
-
+#endif // __dsp__
 
 using dsp_creator_t = dsp *(*)();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.10)
+
+# set the project name
+project(tests)
+
+# specify the C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# add the executable
+add_executable(benchmark-plugin benchmark_plugin.cpp)
+
+# Set the flags for this directory
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O2")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,-O2")
+message("CMAKE_CXX_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_CXX_FLAGS_RELEASE}")
+message("CMAKE_SHARED_LINKER_FLAGS_RELEASE in ${CMAKE_CURRENT_SOURCE_DIR} = ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
+
+# include
+include_directories(benchmark-plugin
+    ../resources
+    ../common)
+
+# link against required libraries
+target_link_libraries(benchmark-plugin PRIVATE dl)
+
+# config install
+install(TARGETS benchmark-plugin
+    DESTINATION bins/tests/benchmark)

--- a/tests/benchmark_plugin.cpp
+++ b/tests/benchmark_plugin.cpp
@@ -1,0 +1,64 @@
+#include <dlfcn.h>
+#include <iostream>
+#include "dsp.hpp" // Include the dsp header file
+
+using dsp_creator_t = dsp* (*)();
+
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        std::cerr << "Usage: " << argv[0] << " <path_to_shared_object> <seconds> <sample_rate>\n";
+        return 1;
+    }
+
+    const char* libraryPath = argv[1];
+    int seconds = std::stoi(argv[2]);
+    int sampleRate = std::stoi(argv[3]);
+
+    // Load the shared object
+    std::cout << "Loading library: " << libraryPath << '\n';
+    void* handle = dlopen(libraryPath, RTLD_NOW);
+    if (!handle) {
+        std::cerr << "Cannot open library: " << dlerror() << '\n';
+        return 1;
+    }
+
+    // Reset errors
+    dlerror();
+
+    // Load the version string
+    const char** version_string_ptr = reinterpret_cast<const char**>(dlsym(handle, "dsp_version"));
+    if (!version_string_ptr) {
+        std::cout << "The 'dsp_version' symbol does not exist in the shared library.\n";
+        return 1;
+    }
+
+    // Load the "create" symbol
+    std::cout << "Loading symbol: create\n";
+    dsp_creator_t create = reinterpret_cast<dsp_creator_t>(dlsym(handle, "create"));
+    const char *dlsym_error = dlerror();
+    if (dlsym_error) {
+        std::cerr << "Cannot load symbol 'create': " << dlsym_error << '\n';
+        dlclose(handle);
+        return 1;
+    }
+
+    // Create an instance of the class
+    std::cout << "Creating instance\n";
+    dsp* instance = create();
+
+    // Set sample rate
+    std::cout << "Setting sample rate: " << sampleRate << '\n';
+    instance->setSampleRate(sampleRate);
+
+    // Invoking instanceConstants method
+    std::cout << "Invoking instanceConstants method\n";
+    instance->instanceConstants();
+
+    // Actually perform the benchmark
+    std::cout << "Invoking benchmark method\n";
+    instance->benchmark(seconds);
+
+    // Close the library
+    std::cout << "Deleting instance\n";
+    dlclose(handle);
+}


### PR DESCRIPTION
What is added by this PR

Extension to build system

Added cmake to build plugins
Added Dockerfile for offline build & runtime emulation with qemu
Extensions to dsp.hpp

Possible to set samplerate of the plugin during init
Implemented file paths stored in std:string array, with util methods, up to MAXFILES
Macros for linear to db, map, selector
Implemented benchmark utility
New plugins

Equalizer, taken from AIDA-X plugin equalizer stack
Aida-x-convolver, leveraging PFFFT library, from AIDA-X plugin
Aida-x-player, leveraging RTNeural engine, from AIDA-X plugin
Testing

Created single binaries / utils (see tests) to benchmark plugins and test basic functionalities
Breaking changes: afaik, none

Depends on: upgraded gcc/libstdc++ (runtime) on the device

Notes to app developers: the app or host or effectsLoading service should now invoke setSampleRate() and
setFilePath() if the symbols are available in the .so, prior to invoke instanceConstants(), which for
plugins that uses files will perform fopen and allocate objs in memory for later usage.
As a consequence and as a general rule, instanceConstants() should never be called from an audio rt thread (see Bela.io
codebase)